### PR TITLE
fsck.fat: add the -m (mmap) option

### DIFF
--- a/manpages/de/fsck.fat.de.8
+++ b/manpages/de/fsck.fat.de.8
@@ -30,7 +30,7 @@
 \fBfsck.fat\fP \- check and repair MS\-DOS filesystems
 
 .SH SYNOPSIS
-\fBfsck.fat\fP|\fBfsck.msdos\fP|\fBfsck.vfat\fP [\-aAflnprtvVwy] [\-d \fIPATH\fP \-d\ \&\fI...\fP] [\-u\ \fIPATH\fP \-u \fI...\fP] \fIDEVICE\fP
+\fBfsck.fat\fP|\fBfsck.msdos\fP|\fBfsck.vfat\fP [\-aAflmnprtvVwy] [\-d \fIPATH\fP \-d\ \&\fI...\fP] [\-u\ \fIPATH\fP \-u \fI...\fP] \fIDEVICE\fP
 
 .SH DESCRIPTION
 \fBfsck.fat\fP verifies the consistency of MS\-DOS filesystems and optionally
@@ -116,6 +116,11 @@ Salvage unused cluster chains to files. By default, unused clusters are
 added to the free disk space except in auto mode (\fB\-a\fP).
 .IP \fB\-l\fP 4
 List path names of files being processed.
+.IP \fB\-m\fP 4
+Use mmap() to read the FAT. This reduces memory consumption because the FAT
+will only be read into memory when it is actually accessed. This is only
+possible when changes are written to disk immediately (\fB\-w\fP), which
+requires the \fB\-a\fP or \fB\-r\fP option as well.
 .IP \fB\-n\fP 4
 No\-operation mode: non\-interactively check for errors, but don't write
 anything to the filesystem.

--- a/manpages/en/fsck.fat.8
+++ b/manpages/en/fsck.fat.8
@@ -25,7 +25,7 @@
 \fBfsck.fat\fR \- check and repair MS\-DOS filesystems
 
 .SH SYNOPSIS
-\fBfsck.fat\fR|\fBfsck.msdos\fR|\fBfsck.vfat\fR [\-aAflnprtvVwy] [\-d \fIPATH\fR \-d\ \fI...\fR] [\-u\ \fIPATH\fR \-u \fI...\fR] \fIDEVICE\fR
+\fBfsck.fat\fR|\fBfsck.msdos\fR|\fBfsck.vfat\fR [\-aAflmnprtvVwy] [\-d \fIPATH\fR \-d\ \fI...\fR] [\-u\ \fIPATH\fR \-u \fI...\fR] \fIDEVICE\fR
 
 .SH DESCRIPTION
 \fBfsck.fat\fR verifies the consistency of MS\-DOS filesystems and optionally tries to repair them.
@@ -87,6 +87,8 @@ Delete the specified file. If more that one file with that name exists, the firs
 Salvage unused cluster chains to files. By default, unused clusters are added to the free disk space except in auto mode (\fB\-a\fR).
 .IP "\fB\-l\fR" 4
 List path names of files being processed.
+.IP "\fB\-m\fR" 4
+Use mmap() to read the FAT. This reduces memory consumption because the FAT will only be read into memory when it is actually accessed. This is only possible when changes are written to disk immediately (\fB\-w\fR), which requires the \fB\-a\fR or \fB\-r\fR option as well.
 .IP "\fB\-n\fR" 4
 No\-operation mode: non\-interactively check for errors, but don't write
 anything to the filesystem.

--- a/manpages/po/de/fsck.fat.8.po
+++ b/manpages/po/de/fsck.fat.8.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: dosfstools VERSION\n"
-"POT-Creation-Date: 2014-11-12 00:52+0100\n"
+"POT-Creation-Date: 2014-11-27 13:17+0100\n"
 "PO-Revision-Date: 2013-06-06 09:34+0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -56,30 +56,30 @@ msgid "OPTIONS"
 msgstr ""
 
 #. type: SH
-#: en/fatlabel.8:41 en/fsck.fat.8:128 en/mkfs.fat.8:78
+#: en/fatlabel.8:41 en/fsck.fat.8:130 en/mkfs.fat.8:78
 #, no-wrap
 msgid "SEE ALSO"
 msgstr ""
 
 #. type: Plain text
-#: en/fatlabel.8:45 en/fsck.fat.8:132
+#: en/fatlabel.8:45 en/fsck.fat.8:134
 msgid "B<mkfs.fat>(8)"
 msgstr ""
 
 #. type: SH
-#: en/fatlabel.8:46 en/fsck.fat.8:133 en/mkfs.fat.8:83
+#: en/fatlabel.8:46 en/fsck.fat.8:135 en/mkfs.fat.8:83
 #, no-wrap
 msgid "HOMEPAGE"
 msgstr ""
 
 #. type: SH
-#: en/fatlabel.8:49 en/fsck.fat.8:136 en/mkfs.fat.8:86
+#: en/fatlabel.8:49 en/fsck.fat.8:138 en/mkfs.fat.8:86
 #, no-wrap
 msgid "AUTHORS"
 msgstr ""
 
 #. type: Plain text
-#: en/fatlabel.8:50 en/fsck.fat.8:137 en/mkfs.fat.8:87
+#: en/fatlabel.8:50 en/fsck.fat.8:139 en/mkfs.fat.8:87
 msgid ""
 "B<dosfstools> were written by Werner Almesberger E<lt>I<werner."
 "almesberger@lrc.di.epfl.ch>E<gt>, Roman Hodek E<lt>I<Roman.Hodek@informatik."
@@ -101,8 +101,8 @@ msgstr ""
 #. type: Plain text
 #: en/fsck.fat.8:29
 msgid ""
-"B<fsck.fat>|B<fsck.msdos>|B<fsck.vfat> [-aAflnprtvVwy] [-d I<PATH> -d\\ I<..."
-">] [-u\\ I<PATH> -u I<...>] I<DEVICE>"
+"B<fsck.fat>|B<fsck.msdos>|B<fsck.vfat> [-aAflmnprtvVwy] [-d I<PATH> -d\\ "
+"I<...>] [-u\\ I<PATH> -u I<...>] I<DEVICE>"
 msgstr ""
 
 #. type: Plain text
@@ -337,59 +337,74 @@ msgstr ""
 #. type: IP
 #: en/fsck.fat.8:90
 #, no-wrap
+msgid "B<-m>"
+msgstr ""
+
+#. type: Plain text
+#: en/fsck.fat.8:92
+msgid ""
+"Use mmap() to read the FAT. This reduces memory consumption because the FAT "
+"will only be read into memory when it is actually accessed. This is only "
+"possible when changes are written to disk immediately (B<-w>), which "
+"requires the B<-a> or B<-r> option as well."
+msgstr ""
+
+#. type: IP
+#: en/fsck.fat.8:92
+#, no-wrap
 msgid "B<-n>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:93
+#: en/fsck.fat.8:95
 msgid ""
 "No-operation mode: non-interactively check for errors, but don't write "
 "anything to the filesystem."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:93
+#: en/fsck.fat.8:95
 #, no-wrap
 msgid "B<-p>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:95
+#: en/fsck.fat.8:97
 msgid "Same as (B<-a>), for compatibility with other *fsck."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:95
+#: en/fsck.fat.8:97
 #, no-wrap
 msgid "B<-r>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:98
+#: en/fsck.fat.8:100
 msgid ""
 "Interactively repair the filesystem. The user is asked for advice whenever "
 "there is more than one approach to fix an inconsistency."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:98
+#: en/fsck.fat.8:100
 #, no-wrap
 msgid "B<-t>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:100
+#: en/fsck.fat.8:102
 msgid "Mark unreadable clusters as bad."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:100
+#: en/fsck.fat.8:102
 #, no-wrap
 msgid "B<-u>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:102
+#: en/fsck.fat.8:104
 msgid ""
 "Try to undelete the specified file. B<fsck.fat> tries to allocate a chain of "
 "contiguous unallocated clusters beginning with the start cluster of the "
@@ -397,24 +412,24 @@ msgid ""
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:102 en/mkfs.fat.8:72
+#: en/fsck.fat.8:104 en/mkfs.fat.8:72
 #, no-wrap
 msgid "B<-v>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:104
+#: en/fsck.fat.8:106
 msgid "Verbose mode. Generates slightly more output."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:104
+#: en/fsck.fat.8:106
 #, no-wrap
 msgid "B<-V>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:106
+#: en/fsck.fat.8:108
 msgid ""
 "Perform a verification pass. The filesystem check is repeated after the "
 "first run. The second pass should never report any fixable errors. It may "
@@ -424,91 +439,91 @@ msgid ""
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:106
+#: en/fsck.fat.8:108
 #, no-wrap
 msgid "B<-w>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:108
+#: en/fsck.fat.8:110
 msgid "Write changes to disk immediately."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:108
+#: en/fsck.fat.8:110
 #, no-wrap
 msgid "B<-y>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:110
+#: en/fsck.fat.8:112
 msgid ""
 "Same as B<-a> (automatically repair filesystem) for compatibility with other "
 "fsck tools."
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:112
+#: en/fsck.fat.8:114
 msgid ""
 "B<Note:> If B<-a> and B<-r> are absent, the filesystem is only checked, but "
 "not repaired."
 msgstr ""
 
 #. type: SH
-#: en/fsck.fat.8:113
+#: en/fsck.fat.8:115
 #, no-wrap
 msgid "EXIT STATUS"
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:114
+#: en/fsck.fat.8:116
 #, no-wrap
 msgid "0"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:116
+#: en/fsck.fat.8:118
 msgid "No recoverable errors have been detected."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:116
+#: en/fsck.fat.8:118
 #, no-wrap
 msgid "1"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:118
+#: en/fsck.fat.8:120
 msgid ""
 "Recoverable errors have been detected or B<fsck.fat> has discovered an "
 "internal inconsistency."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:118
+#: en/fsck.fat.8:120
 #, no-wrap
 msgid "2"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:120
+#: en/fsck.fat.8:122
 msgid "Usage error. B<fsck.fat> did not access the filesystem."
 msgstr ""
 
 #. type: SH
-#: en/fsck.fat.8:121
+#: en/fsck.fat.8:123
 #, no-wrap
 msgid "FILES"
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:122
+#: en/fsck.fat.8:124
 #, no-wrap
 msgid "fsck0000.rec, fsck0001.rec, ..."
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:124
+#: en/fsck.fat.8:126
 msgid ""
 "When recovering from a corrupted filesystem, B<fsck.fat> dumps recovered "
 "data into files named 'fsckNNNN.rec' in the top level directory of the "
@@ -516,13 +531,13 @@ msgid ""
 msgstr ""
 
 #. type: SH
-#: en/fsck.fat.8:125 en/mkfs.fat.8:75
+#: en/fsck.fat.8:127 en/mkfs.fat.8:75
 #, no-wrap
 msgid "BUGS"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:127
+#: en/fsck.fat.8:129
 msgid ""
 "Does not create . and .. files where necessary. Does not remove entirely "
 "empty directories. Should give more diagnostic messages. Undeleting files "
@@ -530,12 +545,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:130 en/mkfs.fat.8:80
+#: en/fsck.fat.8:132 en/mkfs.fat.8:80
 msgid "B<fatlabel>(8)"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:135 en/mkfs.fat.8:85
+#: en/fsck.fat.8:137 en/mkfs.fat.8:85
 msgid ""
 "More information about B<fsck.fat> and B<dosfstools> can be found at "
 "E<lt>I<http://daniel-baumann.ch/software/dosfstools/>E<gt>."

--- a/manpages/pot/fsck.fat.8.pot
+++ b/manpages/pot/fsck.fat.8.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: dosfstools VERSION\n"
-"POT-Creation-Date: 2014-11-12 00:52+0100\n"
+"POT-Creation-Date: 2014-11-27 13:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,30 +59,30 @@ msgid "OPTIONS"
 msgstr ""
 
 #. type: SH
-#: en/fatlabel.8:41 en/fsck.fat.8:128 en/mkfs.fat.8:78
+#: en/fatlabel.8:41 en/fsck.fat.8:130 en/mkfs.fat.8:78
 #, no-wrap
 msgid "SEE ALSO"
 msgstr ""
 
 #. type: Plain text
-#: en/fatlabel.8:45 en/fsck.fat.8:132
+#: en/fatlabel.8:45 en/fsck.fat.8:134
 msgid "B<mkfs.fat>(8)"
 msgstr ""
 
 #. type: SH
-#: en/fatlabel.8:46 en/fsck.fat.8:133 en/mkfs.fat.8:83
+#: en/fatlabel.8:46 en/fsck.fat.8:135 en/mkfs.fat.8:83
 #, no-wrap
 msgid "HOMEPAGE"
 msgstr ""
 
 #. type: SH
-#: en/fatlabel.8:49 en/fsck.fat.8:136 en/mkfs.fat.8:86
+#: en/fatlabel.8:49 en/fsck.fat.8:138 en/mkfs.fat.8:86
 #, no-wrap
 msgid "AUTHORS"
 msgstr ""
 
 #. type: Plain text
-#: en/fatlabel.8:50 en/fsck.fat.8:137 en/mkfs.fat.8:87
+#: en/fatlabel.8:50 en/fsck.fat.8:139 en/mkfs.fat.8:87
 msgid ""
 "B<dosfstools> were written by Werner Almesberger E<lt>I<werner."
 "almesberger@lrc.di.epfl.ch>E<gt>, Roman Hodek E<lt>I<Roman.Hodek@informatik."
@@ -104,8 +104,8 @@ msgstr ""
 #. type: Plain text
 #: en/fsck.fat.8:29
 msgid ""
-"B<fsck.fat>|B<fsck.msdos>|B<fsck.vfat> [-aAflnprtvVwy] [-d I<PATH> -d\\ I<..."
-">] [-u\\ I<PATH> -u I<...>] I<DEVICE>"
+"B<fsck.fat>|B<fsck.msdos>|B<fsck.vfat> [-aAflmnprtvVwy] [-d I<PATH> -d\\ "
+"I<...>] [-u\\ I<PATH> -u I<...>] I<DEVICE>"
 msgstr ""
 
 #. type: Plain text
@@ -340,59 +340,74 @@ msgstr ""
 #. type: IP
 #: en/fsck.fat.8:90
 #, no-wrap
+msgid "B<-m>"
+msgstr ""
+
+#. type: Plain text
+#: en/fsck.fat.8:92
+msgid ""
+"Use mmap() to read the FAT. This reduces memory consumption because the FAT "
+"will only be read into memory when it is actually accessed. This is only "
+"possible when changes are written to disk immediately (B<-w>), which "
+"requires the B<-a> or B<-r> option as well."
+msgstr ""
+
+#. type: IP
+#: en/fsck.fat.8:92
+#, no-wrap
 msgid "B<-n>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:93
+#: en/fsck.fat.8:95
 msgid ""
 "No-operation mode: non-interactively check for errors, but don't write "
 "anything to the filesystem."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:93
+#: en/fsck.fat.8:95
 #, no-wrap
 msgid "B<-p>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:95
+#: en/fsck.fat.8:97
 msgid "Same as (B<-a>), for compatibility with other *fsck."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:95
+#: en/fsck.fat.8:97
 #, no-wrap
 msgid "B<-r>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:98
+#: en/fsck.fat.8:100
 msgid ""
 "Interactively repair the filesystem. The user is asked for advice whenever "
 "there is more than one approach to fix an inconsistency."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:98
+#: en/fsck.fat.8:100
 #, no-wrap
 msgid "B<-t>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:100
+#: en/fsck.fat.8:102
 msgid "Mark unreadable clusters as bad."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:100
+#: en/fsck.fat.8:102
 #, no-wrap
 msgid "B<-u>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:102
+#: en/fsck.fat.8:104
 msgid ""
 "Try to undelete the specified file. B<fsck.fat> tries to allocate a chain of "
 "contiguous unallocated clusters beginning with the start cluster of the "
@@ -400,24 +415,24 @@ msgid ""
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:102 en/mkfs.fat.8:72
+#: en/fsck.fat.8:104 en/mkfs.fat.8:72
 #, no-wrap
 msgid "B<-v>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:104
+#: en/fsck.fat.8:106
 msgid "Verbose mode. Generates slightly more output."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:104
+#: en/fsck.fat.8:106
 #, no-wrap
 msgid "B<-V>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:106
+#: en/fsck.fat.8:108
 msgid ""
 "Perform a verification pass. The filesystem check is repeated after the "
 "first run. The second pass should never report any fixable errors. It may "
@@ -427,91 +442,91 @@ msgid ""
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:106
+#: en/fsck.fat.8:108
 #, no-wrap
 msgid "B<-w>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:108
+#: en/fsck.fat.8:110
 msgid "Write changes to disk immediately."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:108
+#: en/fsck.fat.8:110
 #, no-wrap
 msgid "B<-y>"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:110
+#: en/fsck.fat.8:112
 msgid ""
 "Same as B<-a> (automatically repair filesystem) for compatibility with other "
 "fsck tools."
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:112
+#: en/fsck.fat.8:114
 msgid ""
 "B<Note:> If B<-a> and B<-r> are absent, the filesystem is only checked, but "
 "not repaired."
 msgstr ""
 
 #. type: SH
-#: en/fsck.fat.8:113
+#: en/fsck.fat.8:115
 #, no-wrap
 msgid "EXIT STATUS"
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:114
+#: en/fsck.fat.8:116
 #, no-wrap
 msgid "0"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:116
+#: en/fsck.fat.8:118
 msgid "No recoverable errors have been detected."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:116
+#: en/fsck.fat.8:118
 #, no-wrap
 msgid "1"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:118
+#: en/fsck.fat.8:120
 msgid ""
 "Recoverable errors have been detected or B<fsck.fat> has discovered an "
 "internal inconsistency."
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:118
+#: en/fsck.fat.8:120
 #, no-wrap
 msgid "2"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:120
+#: en/fsck.fat.8:122
 msgid "Usage error. B<fsck.fat> did not access the filesystem."
 msgstr ""
 
 #. type: SH
-#: en/fsck.fat.8:121
+#: en/fsck.fat.8:123
 #, no-wrap
 msgid "FILES"
 msgstr ""
 
 #. type: IP
-#: en/fsck.fat.8:122
+#: en/fsck.fat.8:124
 #, no-wrap
 msgid "fsck0000.rec, fsck0001.rec, ..."
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:124
+#: en/fsck.fat.8:126
 msgid ""
 "When recovering from a corrupted filesystem, B<fsck.fat> dumps recovered "
 "data into files named 'fsckNNNN.rec' in the top level directory of the "
@@ -519,13 +534,13 @@ msgid ""
 msgstr ""
 
 #. type: SH
-#: en/fsck.fat.8:125 en/mkfs.fat.8:75
+#: en/fsck.fat.8:127 en/mkfs.fat.8:75
 #, no-wrap
 msgid "BUGS"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:127
+#: en/fsck.fat.8:129
 msgid ""
 "Does not create . and .. files where necessary. Does not remove entirely "
 "empty directories. Should give more diagnostic messages. Undeleting files "
@@ -533,12 +548,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:130 en/mkfs.fat.8:80
+#: en/fsck.fat.8:132 en/mkfs.fat.8:80
 msgid "B<fatlabel>(8)"
 msgstr ""
 
 #. type: Plain text
-#: en/fsck.fat.8:135 en/mkfs.fat.8:85
+#: en/fsck.fat.8:137 en/mkfs.fat.8:85
 msgid ""
 "More information about B<fsck.fat> and B<dosfstools> can be found at "
 "E<lt>I<http://daniel-baumann.ch/software/dosfstools/>E<gt>."

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -41,7 +41,7 @@
 #include "check.h"
 
 int interactive = 0, rw = 0, list = 0, test = 0, verbose = 0, write_immed = 0;
-int atari_format = 0;
+int atari_format = 0, use_mmap = 0;
 unsigned n_files = 0;
 void *mem_queue = NULL;
 

--- a/src/fsck.fat.c
+++ b/src/fsck.fat.c
@@ -43,7 +43,7 @@
 #include "charconv.h"
 
 int interactive = 0, rw = 0, list = 0, test = 0, verbose = 0, write_immed = 0;
-int atari_format = 0, boot_only = 0;
+int atari_format = 0, boot_only = 0, use_mmap = 0;
 unsigned n_files = 0;
 void *mem_queue = NULL;
 
@@ -60,6 +60,8 @@ static void usage(char *name)
     fprintf(stderr, "  -d path  drop that file\n");
     fprintf(stderr, "  -f       salvage unused chains to files\n");
     fprintf(stderr, "  -l       list path names\n");
+    fprintf(stderr,
+            "  -l       use mmap to read FAT (requires -w and -r or -a)\n");
     fprintf(stderr,
 	    "  -n       no-op, check non-interactively without changing\n");
     fprintf(stderr, "  -p       same as -a, for compat with other *fsck\n");
@@ -112,7 +114,7 @@ int main(int argc, char **argv)
     interactive = 1;
     check_atari();
 
-    while ((c = getopt(argc, argv, "Aac:d:bflnprtu:vVwy")) != EOF)
+    while ((c = getopt(argc, argv, "Aac:d:bflmnprtu:vVwy")) != EOF)
 	switch (c) {
 	case 'A':		/* toggle Atari format */
 	    atari_format = !atari_format;
@@ -141,6 +143,9 @@ int main(int argc, char **argv)
 	case 'l':
 	    list = 1;
 	    break;
+        case 'm':
+            use_mmap = 1;
+            break;
 	case 'n':
 	    rw = 0;
 	    interactive = 0;
@@ -171,6 +176,10 @@ int main(int argc, char **argv)
     if ((test || write_immed) && !rw) {
 	fprintf(stderr, "-t and -w require -a or -r\n");
 	exit(2);
+    }
+    if (use_mmap && !write_immed) {
+        fprintf(stderr, "-m requires explicit -w and -a or -r\n");
+        exit(2);
     }
     if (optind != argc - 1)
 	usage(argv[0]);

--- a/src/fsck.fat.h
+++ b/src/fsck.fat.h
@@ -176,7 +176,7 @@ typedef struct {
 } DOS_FS;
 
 extern int interactive, rw, list, verbose, test, write_immed;
-extern int atari_format;
+extern int atari_format, use_mmap;
 extern unsigned n_files;
 extern void *mem_queue;
 

--- a/src/io.h
+++ b/src/io.h
@@ -38,6 +38,16 @@ void fs_open(char *path, int rw);
 /* Opens the filesystem PATH. If RW is zero, the filesystem is opened
    read-only, otherwise, it is opened read-write. */
 
+void *fs_mmap(loff_t pos, int size);
+
+/* maps SIZE bytes starting at POS into memory. Does not perform any
+   changes. */
+
+void fs_munmap(void *mapped, int size);
+
+/* unmaps SIZE bytes at mapped, which have been mapped before with fs_mmap
+ */
+
 void fs_read(loff_t pos, int size, void *data);
 
 /* Reads SIZE bytes starting at POS into DATA. Performs all applicable


### PR DESCRIPTION
By using mmap, we avoid allocating the entire FAT table, and we make it
possible for the OS to read in pages from the disk on demand only.

This option is only available in combination with -w, because any write
to the mmapped region may be written to disk at any time.

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=771091

Limitations and possible improvements:
- Don't know if mmap is available with DJGPP.
- mmap could be used unconditionally if -w is given.
- The conditional handling could be moved to fs_read/fs_write.
- The same change would be useful in fatlabel and mkfs.fat.
