### PR TITLE
mkfs.fat: fix incorrect int type

### DIFF
--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1412,7 +1412,7 @@ int main(int argc, char **argv)
 
     gettimeofday(&create_timeval, NULL);
     create_time = create_timeval.tv_sec;
-    volume_id = (u_int32_t) ((create_timeval.tv_sec << 20) | create_timeval.tv_usec);	/* Default volume ID = creation time, fudged for more uniqueness */
+    volume_id = (uint32_t) ((create_timeval.tv_sec << 20) | create_timeval.tv_usec);	/* Default volume ID = creation time, fudged for more uniqueness */
     check_atari();
 
     printf("mkfs.fat " VERSION " (" VERSION_DATE ")\n");


### PR DESCRIPTION
`u_int32_t` is not a stanard type, while `uint32_t` is. This fixes builds
with the musl C library, which only defines so-called "clean" headers;
build failures are like (back-quotes and elision manually added for
readability):

    http://autobuild.buildroot.org/results/a09/a0923d7f6d4dbae02eba4c5024bbdae3a52aa85a/build-end.log

    /home/peko/autobuild/instance-1/output/host/usr/bin/x86_64-linux-gcc -D_LARGEFILE_SOURCE \
        -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64   -Os  -D_GNU_SOURCE -D_LARGEFILE_SOURCE \
        -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -c -o mkfs.fat.o src/mkfs.fat.c
    src/mkfs.fat.c: In function 'main':
    src/mkfs.fat.c:1415:18: error: 'u_int32_t' undeclared (first use in this function)
         volume_id = (u_int32_t) ((create_timeval.tv_sec << 20) | create_timeval.tv_usec); [...]
                      ^
    src/mkfs.fat.c:1415:18: note: each undeclared identifier is reported only once for each
    function it appears in

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>