### PR TITLE
Compile with musl libc

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -156,7 +156,7 @@ static void check_backup_boot(DOS_FS * fs, struct boot_sector *b, int lss)
 	    fs->backupboot_start = bbs * lss;
 	    b->backup_boot = htole16(bbs);
 	    fs_write(fs->backupboot_start, sizeof(*b), b);
-	    fs_write((loff_t) offsetof(struct boot_sector, backup_boot),
+	    fs_write((off_t) offsetof(struct boot_sector, backup_boot),
 		     sizeof(b->backup_boot), &b->backup_boot);
 	    printf("Created backup of boot sector in sector %d\n", bbs);
 	    return;
@@ -234,9 +234,9 @@ static void read_fsinfo(DOS_FS * fs, struct boot_sector *b, int lss)
 		    break;
 	    if (s > 0 && s < le16toh(b->reserved)) {
 		init_fsinfo(&i);
-		fs_write((loff_t) s * lss, sizeof(i), &i);
+		fs_write((off_t) s * lss, sizeof(i), &i);
 		b->info_sector = htole16(s);
-		fs_write((loff_t) offsetof(struct boot_sector, info_sector),
+		fs_write((off_t) offsetof(struct boot_sector, info_sector),
 			 sizeof(b->info_sector), &b->info_sector);
 		if (fs->backupboot_start)
 		    fs_write(fs->backupboot_start +
@@ -328,7 +328,7 @@ void read_boot(DOS_FS * fs)
     unsigned total_sectors;
     unsigned short logical_sector_size, sectors;
     unsigned fat_length;
-    loff_t data_size;
+    off_t data_size;
 
     fs_read(0, sizeof(b), &b);
     logical_sector_size = GET_UNALIGNED_W(b.sector_size);
@@ -353,18 +353,18 @@ void read_boot(DOS_FS * fs)
     if (verbose)
 	printf("Checking we can access the last sector of the filesystem\n");
     /* Can't access last odd sector anyway, so round down */
-    fs_test((loff_t) ((total_sectors & ~1) - 1) * (loff_t) logical_sector_size,
+    fs_test((off_t) ((total_sectors & ~1) - 1) * (off_t) logical_sector_size,
 	    logical_sector_size);
     fat_length = le16toh(b.fat_length) ?
 	le16toh(b.fat_length) : le32toh(b.fat32_length);
-    fs->fat_start = (loff_t) le16toh(b.reserved) * logical_sector_size;
-    fs->root_start = ((loff_t) le16toh(b.reserved) + b.fats * fat_length) *
+    fs->fat_start = (off_t) le16toh(b.reserved) * logical_sector_size;
+    fs->root_start = ((off_t) le16toh(b.reserved) + b.fats * fat_length) *
 	logical_sector_size;
     fs->root_entries = GET_UNALIGNED_W(b.dir_entries);
     fs->data_start = fs->root_start + ROUND_TO_MULTIPLE(fs->root_entries <<
 							MSDOS_DIR_BITS,
 							logical_sector_size);
-    data_size = (loff_t) total_sectors *logical_sector_size - fs->data_start;
+    data_size = (off_t) total_sectors *logical_sector_size - fs->data_start;
     fs->data_clusters = data_size / fs->cluster_size;
     fs->root_cluster = 0;	/* indicates standard, pre-FAT32 root dir */
     fs->fsinfo_start = 0;	/* no FSINFO structure */
@@ -492,10 +492,10 @@ static void write_boot_label(DOS_FS * fs, char *label)
     }
 }
 
-loff_t find_volume_de(DOS_FS * fs, DIR_ENT * de)
+off_t find_volume_de(DOS_FS * fs, DIR_ENT * de)
 {
     uint32_t cluster;
-    loff_t offset;
+    off_t offset;
     int i;
 
     if (fs->root_cluster) {
@@ -526,7 +526,7 @@ static void write_volume_label(DOS_FS * fs, char *label)
 {
     time_t now = time(NULL);
     struct tm *mtime = localtime(&now);
-    loff_t offset;
+    off_t offset;
     int created;
     DIR_ENT de;
 

--- a/src/boot.h
+++ b/src/boot.h
@@ -25,7 +25,7 @@
 
 void read_boot(DOS_FS * fs);
 void write_label(DOS_FS * fs, char *label);
-loff_t find_volume_de(DOS_FS * fs, DIR_ENT * de);
+off_t find_volume_de(DOS_FS * fs, DIR_ENT * de);
 
 /* Reads the boot sector from the currently open device and initializes *FS */
 

--- a/src/check.c
+++ b/src/check.c
@@ -64,7 +64,7 @@ static DOS_FILE *root;
 	p->dir_ent.start = htole16(__v&0xffff);				\
 	p->dir_ent.starthi = htole16(__v>>16);				\
 	__v = htole32(__v);						\
-	fs_write((loff_t)offsetof(struct boot_sector,root_cluster),	\
+	fs_write((off_t)offsetof(struct boot_sector,root_cluster),	\
 	         sizeof(((struct boot_sector *)0)->root_cluster),	\
 		 &__v);							\
     }									\
@@ -75,16 +75,16 @@ static DOS_FILE *root;
     }									\
   } while(0)
 
-loff_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern)
+off_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern)
 {
     static int curr_num = 0;
-    loff_t offset;
+    off_t offset;
 
     if (fs->root_cluster) {
 	DIR_ENT d2;
 	int i = 0, got = 0;
 	uint32_t clu_num, prev = 0;
-	loff_t offset2;
+	off_t offset2;
 
 	clu_num = fs->root_cluster;
 	offset = cluster_start(fs, clu_num);
@@ -336,7 +336,7 @@ static int bad_name(DOS_FILE * file)
     return 0;
 }
 
-static void lfn_remove(loff_t from, loff_t to)
+static void lfn_remove(off_t from, off_t to)
 {
     DIR_ENT empty;
 
@@ -954,7 +954,7 @@ static void new_dir(void)
  * @param           cp
  */
 static void add_file(DOS_FS * fs, DOS_FILE *** chain, DOS_FILE * parent,
-		     loff_t offset, FDSC ** cp)
+		     off_t offset, FDSC ** cp)
 {
     DOS_FILE *new;
     DIR_ENT de;

--- a/src/check.h
+++ b/src/check.h
@@ -23,7 +23,7 @@
 #ifndef _CHECK_H
 #define _CHECK_H
 
-loff_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern);
+off_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern);
 
 /* Allocate a free slot in the root directory for a new file. The file name is
    constructed after 'pattern', which must include a %d type format for printf

--- a/src/fat.c
+++ b/src/fat.c
@@ -195,7 +195,7 @@ void set_fat(DOS_FS * fs, uint32_t cluster, int32_t new)
 {
     unsigned char *data = NULL;
     int size;
-    loff_t offs;
+    off_t offs;
 
     if (cluster > fs->data_clusters + 1) {
 	die("Internal error: cluster out of range in set_fat() (%lu > %lu).",
@@ -291,9 +291,9 @@ uint32_t next_cluster(DOS_FS * fs, uint32_t cluster)
     return FAT_IS_EOF(fs, value) ? -1 : value;
 }
 
-loff_t cluster_start(DOS_FS * fs, uint32_t cluster)
+off_t cluster_start(DOS_FS * fs, uint32_t cluster)
 {
-    return fs->data_start + ((loff_t) cluster -
+    return fs->data_start + ((off_t) cluster -
 			     2) * (uint64_t)fs->cluster_size;
 }
 
@@ -502,7 +502,7 @@ void reclaim_file(DOS_FS * fs)
 	/* If this cluster is the head of an orphan chain... */
 	if (get_owner(fs, i) == &orphan && !num_refs[i]) {
 	    DIR_ENT de;
-	    loff_t offset;
+	    off_t offset;
 	    files++;
 	    offset = alloc_rootdir_entry(fs, &de, "FSCK%04dREC");
 	    de.start = htole16(i & 0xffff);

--- a/src/fat.h
+++ b/src/fat.h
@@ -49,7 +49,7 @@ uint32_t next_cluster(DOS_FS * fs, uint32_t cluster);
    last cluster of the respective cluster chain. CLUSTER must not be a bad
    cluster. */
 
-loff_t cluster_start(DOS_FS * fs, uint32_t cluster);
+off_t cluster_start(DOS_FS * fs, uint32_t cluster);
 
 /* Returns the byte offset of CLUSTER, relative to the respective device. */
 

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
     char *device = NULL;
     char label[12] = { 0 };
 
-    loff_t offset;
+    off_t offset;
     DIR_ENT de;
 
     check_atari();

--- a/src/fsck.fat.h
+++ b/src/fsck.fat.h
@@ -135,8 +135,8 @@ typedef struct {
 typedef struct _dos_file {
     DIR_ENT dir_ent;
     char *lfn;
-    loff_t offset;
-    loff_t lfn_offset;
+    off_t offset;
+    off_t lfn_offset;
     struct _dos_file *parent;	/* parent directory */
     struct _dos_file *next;	/* next entry */
     struct _dos_file *first;	/* first entry (directory only) */
@@ -149,19 +149,19 @@ typedef struct {
 
 typedef struct {
     int nfats;
-    loff_t fat_start;
+    off_t fat_start;
     unsigned int fat_size;	/* unit is bytes */
     unsigned int fat_bits;	/* size of a FAT entry */
     unsigned int eff_fat_bits;	/* # of used bits in a FAT entry */
     uint32_t root_cluster;	/* 0 for old-style root dir */
-    loff_t root_start;
+    off_t root_start;
     unsigned int root_entries;
-    loff_t data_start;
+    off_t data_start;
     unsigned int cluster_size;
     uint32_t data_clusters;	/* not including two reserved cluster numbers */
-    loff_t fsinfo_start;	/* 0 if not present */
+    off_t fsinfo_start;	/* 0 if not present */
     long free_clusters;
-    loff_t backupboot_start;	/* 0 if not present */
+    off_t backupboot_start;	/* 0 if not present */
     unsigned char *fat;
     DOS_FILE **cluster_owner;
     char *label;

--- a/src/io.c
+++ b/src/io.c
@@ -47,7 +47,7 @@
 
 typedef struct _change {
     void *data;
-    loff_t pos;
+    off_t pos;
     int size;
     struct _change *next;
 } CHANGE;
@@ -59,7 +59,7 @@ unsigned device_no;
 
 #ifdef __DJGPP__
 #include "volume.h"		/* DOS lowlevel disk access functions */
-loff_t llseek(int fd, loff_t offset, int whence)
+off_t llseek(int fd, off_t offset, int whence)
 {
     if ((whence != SEEK_SET) || (fd == 4711))
 	return -1;		/* only those supported */
@@ -71,9 +71,9 @@ loff_t llseek(int fd, loff_t offset, int whence)
 #define read(a,b,c) ReadVolume(b,c)
 #define write(a,b,c) WriteVolume(b,c)
 #else
-loff_t llseek(int fd, loff_t offset, int whence)
+off_t llseek(int fd, off_t offset, int whence)
 {
-    return (loff_t) lseek64(fd, (off64_t) offset, whence);
+    return (off_t) lseek64(fd, (off64_t) offset, whence);
 }
 #endif
 
@@ -117,7 +117,7 @@ void fs_open(char *path, int rw)
  * @param[in]   size    Number of bytes to read
  * @param[out]  data    Where to put the data read
  */
-void fs_read(loff_t pos, int size, void *data)
+void fs_read(off_t pos, int size, void *data)
 {
     CHANGE *walk;
     int got;
@@ -144,7 +144,7 @@ void fs_read(loff_t pos, int size, void *data)
     }
 }
 
-int fs_test(loff_t pos, int size)
+int fs_test(off_t pos, int size)
 {
     void *scratch;
     int okay;
@@ -157,7 +157,7 @@ int fs_test(loff_t pos, int size)
     return okay;
 }
 
-void fs_write(loff_t pos, int size, void *data)
+void fs_write(off_t pos, int size, void *data)
 {
     CHANGE *new;
     int did;

--- a/src/io.h
+++ b/src/io.h
@@ -27,9 +27,7 @@
 #ifndef _IO_H
 #define _IO_H
 
-#include <fcntl.h>		/* for loff_t */
-
-loff_t llseek(int fd, loff_t offset, int whence);
+off_t llseek(int fd, off_t offset, int whence);
 
 /* lseek() analogue for large offsets. */
 
@@ -38,17 +36,17 @@ void fs_open(char *path, int rw);
 /* Opens the filesystem PATH. If RW is zero, the filesystem is opened
    read-only, otherwise, it is opened read-write. */
 
-void fs_read(loff_t pos, int size, void *data);
+void fs_read(off_t pos, int size, void *data);
 
 /* Reads SIZE bytes starting at POS into DATA. Performs all applicable
    changes. */
 
-int fs_test(loff_t pos, int size);
+int fs_test(off_t pos, int size);
 
 /* Returns a non-zero integer if SIZE bytes starting at POS can be read without
    errors. Otherwise, it returns zero. */
 
-void fs_write(loff_t pos, int size, void *data);
+void fs_write(off_t pos, int size, void *data);
 
 /* If write_immed is non-zero, SIZE bytes are written from DATA to the disk,
    starting at POS. If write_immed is zero, the change is added to a list in

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -53,7 +53,7 @@ typedef struct {
 unsigned char *lfn_unicode = NULL;
 unsigned char lfn_checksum;
 int lfn_slot = -1;
-loff_t *lfn_offsets = NULL;
+off_t *lfn_offsets = NULL;
 int lfn_parts = 0;
 
 static unsigned char fat_uni2esc[64] = {
@@ -171,7 +171,7 @@ static void clear_lfn_slots(int start, int end)
     }
 }
 
-void lfn_fix_checksum(loff_t from, loff_t to, const char *short_name)
+void lfn_fix_checksum(off_t from, off_t to, const char *short_name)
 {
     int i;
     uint8_t sum;
@@ -196,7 +196,7 @@ void lfn_reset(void)
 
 /* This function is only called with de->attr == VFAT_LN_ATTR. It stores part
  * of the long name. */
-void lfn_add_slot(DIR_ENT * de, loff_t dir_offset)
+void lfn_add_slot(DIR_ENT * de, off_t dir_offset)
 {
     LFN_ENT *lfn = (LFN_ENT *) de;
     int slot = lfn->id & LFN_ID_SLOTMASK;
@@ -254,7 +254,7 @@ void lfn_add_slot(DIR_ENT * de, loff_t dir_offset)
 	lfn_slot = slot;
 	lfn_checksum = lfn->alias_checksum;
 	lfn_unicode = alloc((lfn_slot * CHARS_PER_LFN + 1) * 2);
-	lfn_offsets = alloc(lfn_slot * sizeof(loff_t));
+	lfn_offsets = alloc(lfn_slot * sizeof(off_t));
 	lfn_parts = 0;
     } else if (lfn_slot == -1 && slot != 0) {
 	/* No LFN in progress, but slot found; start bit missing */
@@ -273,7 +273,7 @@ void lfn_add_slot(DIR_ENT * de, loff_t dir_offset)
 	switch (interactive ? get_key("123", "?") : '2') {
 	case '1':
 	    if (!lfn_offsets)
-		lfn_offsets = alloc(sizeof(loff_t));
+		lfn_offsets = alloc(sizeof(off_t));
 	    lfn_offsets[0] = dir_offset;
 	    clear_lfn_slots(0, 0);
 	    lfn_reset();
@@ -288,7 +288,7 @@ void lfn_add_slot(DIR_ENT * de, loff_t dir_offset)
 	    lfn_slot = slot;
 	    lfn_checksum = lfn->alias_checksum;
 	    lfn_unicode = alloc((lfn_slot * CHARS_PER_LFN + 1) * 2);
-	    lfn_offsets = alloc(lfn_slot * sizeof(loff_t));
+	    lfn_offsets = alloc(lfn_slot * sizeof(off_t));
 	    lfn_parts = 0;
 	    break;
 	}
@@ -320,7 +320,7 @@ void lfn_add_slot(DIR_ENT * de, loff_t dir_offset)
 	switch (interactive ? get_key(can_fix ? "123" : "12", "?") : '2') {
 	case '1':
 	    if (!lfn_offsets) {
-		lfn_offsets = alloc(sizeof(loff_t));
+		lfn_offsets = alloc(sizeof(off_t));
 		lfn_parts = 0;
 	    }
 	    lfn_offsets[lfn_parts++] = dir_offset;
@@ -407,7 +407,7 @@ void lfn_add_slot(DIR_ENT * de, loff_t dir_offset)
 
 /* This function is always called when de->attr != VFAT_LN_ATTR is found, to
  * retrieve the previously constructed LFN. */
-char *lfn_get(DIR_ENT * de, loff_t * lfn_offset)
+char *lfn_get(DIR_ENT * de, off_t * lfn_offset)
 {
     char *lfn;
     uint8_t sum;

--- a/src/lfn.h
+++ b/src/lfn.h
@@ -26,14 +26,14 @@
 void lfn_reset(void);
 /* Reset the state of the LFN parser. */
 
-void lfn_add_slot(DIR_ENT * de, loff_t dir_offset);
+void lfn_add_slot(DIR_ENT * de, off_t dir_offset);
 /* Process a dir slot that is a VFAT LFN entry. */
 
-char *lfn_get(DIR_ENT * de, loff_t * lfn_offset);
+char *lfn_get(DIR_ENT * de, off_t * lfn_offset);
 /* Retrieve the long name for the proper dir entry. */
 
 void lfn_check_orphaned(void);
 
-void lfn_fix_checksum(loff_t from, loff_t to, const char *short_name);
+void lfn_fix_checksum(off_t from, off_t to, const char *short_name);
 
 #endif

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -274,7 +274,7 @@ static long do_check(char *buffer, int try, off_t current_block);
 static void alarm_intr(int alnum);
 static void check_blocks(void);
 static void get_list_blocks(char *filename);
-static int valid_offset(int fd, loff_t offset);
+static int valid_offset(int fd, off_t offset);
 static uint64_t count_blocks(char *filename, int *remainder);
 static void check_mount(char *device_name);
 static void establish_params(int device_num, int size);
@@ -451,7 +451,7 @@ static void get_list_blocks(char *filename)
 /* Given a file descriptor and an offset, check whether the offset is a valid offset for the file - return FALSE if it
    isn't valid or TRUE if it is */
 
-static int valid_offset(int fd, loff_t offset)
+static int valid_offset(int fd, off_t offset)
 {
     char ch;
 
@@ -466,7 +466,7 @@ static int valid_offset(int fd, loff_t offset)
 
 static uint64_t count_blocks(char *filename, int *remainder)
 {
-    loff_t high, low;
+    off_t high, low;
     int fd;
 
     if ((fd = open(filename, O_RDONLY)) < 0) {
@@ -480,7 +480,7 @@ static uint64_t count_blocks(char *filename, int *remainder)
 	for (high = 1; valid_offset(fd, high); high *= 2)
 	    low = high;
 	while (low < high - 1) {
-	    const loff_t mid = (low + high) / 2;
+	    const off_t mid = (low + high) / 2;
 	    if (valid_offset(fd, mid))
 		low = mid;
 	    else
@@ -1277,7 +1277,7 @@ static void setup_tables(void)
 
 #define seekto(pos,errstr)						\
   do {									\
-    loff_t __pos = (pos);						\
+    off_t __pos = (pos);						\
     if (llseek (dev, __pos, SEEK_SET) != __pos)				\
 	error ("seek to " errstr " failed whilst writing tables");	\
   } while(0)


### PR DESCRIPTION
musl (http://musl-libc.org) does not define the type loff_t in its headers, making compilation fail badly. We could use a configure test for loff_t. On the other hand, because we are using AC_SYS_LARGEFILE, loff_t should be the same as off_t anyway (assuming --disable-largefile is not used)