### PR TITLE
src/device_info.c: Fix undefined PATH_MAX under musl

### DIFF
--- a/src/device_info.c
+++ b/src/device_info.c
@@ -17,6 +17,7 @@
 */
 
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <sys/types.h>


### PR DESCRIPTION
In musl libc, PATH_MAX is defined in \<limits.h>.