### PR TITLE
Don't link to udev via LDFLAGS. There's LDADD for such a task.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,12 +34,12 @@ mkfs_common_sources = device_info.c device_info.h \
 mkfs_fat_SOURCES  = mkfs.fat.c msdos_fs.h $(mkfs_common_sources)
 mkfs_fat_CPPFLAGS = -I$(srcdir)/blkdev
 mkfs_fat_CFLAGS   = $(AM_CFLAGS) $(UDEV_CFLAGS)
-mkfs_fat_LDFLAGS  = $(UDEV_LIBS)
+mkfs_fat_LDADD    = $(UDEV_LIBS)
 
 testdevinfo_SOURCES  = testdevinfo.c $(mkfs_common_sources)
 testdevinfo_CPPFLAGS = -I$(srcdir)/blkdev
 testdevinfo_CFLAGS   = $(AM_CFLAGS) $(UDEV_CFLAGS)
-testdevinfo_LDFLAGS  = $(UDEV_LIBS)
+testdevinfo_LDADD    = $(UDEV_LIBS)
 
 
 if COMPAT_SYMLINKS


### PR DESCRIPTION
See also:
https://www.gnu.org/software/automake/manual/html_node/Linking.html

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>