### PR TITLE
Improve OS X endian compatibility and add 2 more files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@ TAGS
 
 aclocal.m4
 autom4te.cache
+config.guess
 config.log
 config.status
+config.sub
 configure
 compile
 depcomp

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_CHECK_HEADERS([\
 		  sys/queue.h \
 		  ])
 
-AC_CHECK_HEADERS([endian.h sys/endian.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h libkern/OSByteOrder.h])
 
 AC_CHECK_DECLS([getmntent], [], [], [[#include <mntent.h>]])
 AC_CHECK_DECLS([getmntinfo], [], [], [[#include <sys/mount.h>]])

--- a/src/endian_compat.h
+++ b/src/endian_compat.h
@@ -5,7 +5,7 @@
 #include <endian.h>
 #elif defined(HAVE_SYS_ENDIAN_H)
 #include <sys/endian.h>
-#elif defined(__APPLE__)
+#elif defined(HAVE_LIBKERN_OSBYTEORDER_H)
 	#include <libkern/OSByteOrder.h>
 
 	#define htobe16(x) OSSwapHostToBigInt16(x)


### PR DESCRIPTION
Use autoconf to check for libkern/OSByteOrder.h existence instead of relying on __APPLE__ definition.
Add a couple of files to gitignore.