### PR TITLE
Switch to AC_CHECK_LIB for iconv library linking.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ if test "x$with_udev" != "xno"; then
 		  [true])
 fi
 
-AC_SEARCH_LIBS(iconv_open, iconv)
+AC_CHECK_LIB(iconv, iconv_open)
 
 # xxd (distributed with vim) is used in the testsuite
 AC_CHECK_PROG([XXD_FOUND], [xxd], [yes])


### PR DESCRIPTION
AC_SEARCH_LIB doesn't work properly for openwrt/lede when building dosfstools
as a package.

Signed-off-by: Álvaro Fernández Rojas noltari@gmail.com
