### PR TITLE
Include limits.h for definition of PATH_MAX

### DIFF
--- a/src/device_info.c
+++ b/src/device_info.c
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "blkdev.h"
 #include "device_info.h"


### PR DESCRIPTION
PATH_MAX is a macro defined in limits.h.
In order to work/compile with musl-libc, include the required header in src/device_info.c