### PR TITLE
add missing \n

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -131,7 +131,7 @@ void read_fat(DOS_FS * fs)
 	    memcpy(first, second, eff_size);
 	}
 	if (first_ok && second_ok) {
-	    printf("FATs differ but appear to be intact.");
+	    printf("FATs differ but appear to be intact.\n");
 	    if (get_choice(1, "  Using first FAT.",
 			   2,
 			   1, "Use first FAT",


### PR DESCRIPTION
To fix this:
```
Starting check/repair pass.
FATs differ but appear to be intact.1) Use first FAT
2) Use second FAT
[12?q]? 
```