### PR TITLE
Fix reading and writing empty labels

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -535,6 +535,8 @@ static void write_volume_label(DOS_FS * fs, char *label)
 	offset = alloc_rootdir_entry(fs, &de, label, 0);
     }
     memcpy(de.name, label, 11);
+    if (memcmp(de.name, "NO NAME    ", 11) == 0)
+        memcpy(de.name, "\xE5          ", 11);
     de.time = htole16((unsigned short)((mtime->tm_sec >> 1) +
 				       (mtime->tm_min << 5) +
 				       (mtime->tm_hour << 11)));

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -81,12 +81,14 @@ int main(int argc, char *argv[])
 
     device = argv[1];
     if (argc == 3) {
-	strncpy(label, argv[2], 11);
 	if (strlen(argv[2]) > 11) {
 	    fprintf(stderr,
 		    "fatlabel: labels can be no longer than 11 characters\n");
 	    exit(1);
 	}
+	sprintf(label, "%-11.11s", argv[2]);
+	if (memcmp(label, "           ", 11) == 0 || label[0] == '\xE5')
+	    memcpy(label, "NO NAME    ", 11);
 	for (i = 0; label[i] && i < 11; i++)
 	    /* don't know if here should be more strict !uppercase(label[i]) */
 	    if (islower(label[i])) {

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -105,10 +105,10 @@ int main(int argc, char *argv[])
 	read_fat(&fs);
     if (!rw) {
 	offset = find_volume_de(&fs, &de);
-	if (offset == 0)
-	    fprintf(stdout, "%.11s\n", fs.label);
-	else
+	if (offset != 0 && !IS_FREE(de.name))
 	    fprintf(stdout, "%.8s%.3s\n", de.name, de.name + 8);
+	else if (memcmp(fs.label, "NO NAME    ", 11) != 0)
+	    fprintf(stdout, "%.11s\n", fs.label);
 	exit(0);
     }
 

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1481,6 +1481,8 @@ int main(int argc, char **argv)
 
 	case 'n':		/* n : Volume name */
 	    sprintf(volume_name, "%-11.11s", optarg);
+	    if (memcmp(volume_name, "           ", MSDOS_NAME) == 0 || volume_name[0] == '\xE5')
+	        memcpy(volume_name, NO_NAME, MSDOS_NAME);
 	    for (i = 0; volume_name[i] && i < 11; i++)
 		/* don't know if here should be more strict !uppercase(label[i]) */
 		if (islower(volume_name[i])) {


### PR DESCRIPTION
Please properly review these changes as I'm not sure if there is no hidden threat. Such nonsense as padding with spaces, two different location for volume label, special first byte which indicate deleted entry or special string "NO NAME    " (instead of empty string) can be really found in FAT.

The good tool for reading label from root FAT directory is `mdir` from mtools. And for inseparability is good `mlabel` and recent `blkid`.

Seems we are missing tests for such FAT nonsenses...