### PR TITLE
Fix signed integer overflow in FSTART

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -47,7 +47,7 @@ static DOS_FILE *root;
 /* get start field of a dir entry */
 #define FSTART(p,fs) \
   ((uint32_t)le16toh(p->dir_ent.start) | \
-   (fs->fat_bits == 32 ? le16toh(p->dir_ent.starthi) << 16 : 0))
+   (fs->fat_bits == 32 ? (uint32_t)le16toh(p->dir_ent.starthi) << 16 : 0))
 
 #define MODIFY(p,i,v)					\
   do {							\


### PR DESCRIPTION
`uint16_t` was promoted to `int`, and then left shift could overflow it.
Add explicit cast to `uint32_t` to avoid undefined behavior.

Found using [american fuzzy lop](http://lcamtuf.coredump.cx/afl/).