### PR TITLE
src/check.c: Fix up mtools created bad dir entries

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -495,6 +495,13 @@ static int handle_dot(DOS_FS * fs, DOS_FILE * file, int dots)
 	    break;
 	}
     }
+    if (file->dir_ent.lcase & FAT_NO_83NAME) {
+	/* Some versions of mtools write these directory entries with random data in
+	   this field. */
+	printf("%s\n  Is a dot with no 8.3 name flag set, clearing.\n", path_name(file));
+	file->dir_ent.lcase &= ~FAT_NO_83NAME;
+	MODIFY(file, lcase, file->dir_ent.lcase);
+    }
     if (!dots) {
 	printf("Root contains directory \"%s\". Dropping it.\n", name);
 	drop_file(fs, file);


### PR DESCRIPTION
mtools writes uninitialized data to the case field of some
directory entries. Running fsck.fat on these filesystems
will cause the directory to get deleted which can lead to
data loss. Detect this situation and clear the flag instead.

mtools patch to fix the original issue:

https://lists.gnu.org/archive/html/info-mtools/2014-08/msg00000.html

Signed-off-by: Will Newton <willn@resin.io>