### PR TITLE
Fix commit 51da71a - Handle conversion between 0xe5 and 0x05

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -298,7 +298,7 @@ static int bad_name(DOS_FILE * file)
 	return 0;
 
     for (i = 0; i < MSDOS_NAME; i++) {
-	if (name[i] < ' ' || name[i] == 0x7f)
+	if ((name[i] < ' ' && !(i == 0 && name[0] == 0x05)) || name[i] == 0x7f)
 	    return 1;
 	if (name[i] > 0x7f)
 	    ++suspicious;

--- a/src/file.c
+++ b/src/file.c
@@ -66,7 +66,13 @@ char *file_name(unsigned char *fixed)
     int i, j;
 
     p = path;
-    for (i = j = 0; i < 8; i++)
+    i = j = 0;
+    if (fixed[0] == 0x05) {
+        put_char(&p, 0xe5);
+        ++i;
+        ++j;
+    }
+    for (; i < 8; i++)
 	if (fixed[i] != ' ') {
 	    while (j++ < i)
 		*p++ = ' ';
@@ -126,7 +132,10 @@ int file_cvt(unsigned char *name, unsigned char *fixed)
 	if (islower(c))
 	    c = toupper(c);
 	if (size) {
-	    *fixed++ = c;
+	    if (size == 8 && c == 0xE5)
+		*fixed++ = 0x05;
+	    else
+		*fixed++ = c;
 	    size--;
 	}
 	name++;

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1131,6 +1131,8 @@ static void setup_tables(void)
     if (memcmp(volume_name, NO_NAME, MSDOS_NAME)) {
 	struct msdos_dir_entry *de = &root_dir[0];
 	memcpy(de->name, volume_name, MSDOS_NAME);
+	if (de->name[0] == 0xe5)
+	    de->name[0] = 0x05;
 	de->attr = ATTR_VOLUME;
 	if (!invariant)
 		ctime = localtime(&create_time);


### PR DESCRIPTION
In commit 51da71a is partial fix for handling leading 0xE5 byte. But fix is not complete, on another two places it needs to be done. In fsck.fat when converting file name entry from FAT directory and in mkfs.fat when writing label to FAT directory.