### PR TITLE
Codepage support for fsck.fat and fatlabel

### DIFF
--- a/manpages/fatlabel.8.in
+++ b/manpages/fatlabel.8.in
@@ -86,6 +86,52 @@ to specified DOS codepage.
 
 It is strongly suggested to not use \fBdosfslabel\fR prior to version 3.0.16.
 .\" ----------------------------------------------------------------------------
+.SH DOS CODEPAGES
+MS-DOS and Windows systems uses DOS (OEM) codepage according to global Language
+Country/Region system settings. DOS codepage is needed for encoding/decoding
+non-ASCII FAT label. Default DOS codepage is 850. See following mapping table
+between DOS codepage and Language Country/Region:
+.TS
+tab(:);
+c lx.
+\fBCodepage\fR:\fBLanguage Country/Region\fR
+437:T{
+English (India), English (Malaysia), English (Republic of the Philippines),
+English (Singapore), English (South Africa), English (United States),
+English (Zimbabwe), Filipino, Hausa, Igbo, Inuktitut, Kinyarwanda, Kiswahili,
+Yoruba
+T}
+737:Greek
+775:Estonian, Latvian, Lithuanian
+850:T{
+Afrikaans, Alsatian, Basque, Breton, Catalan, Corsican, Danish, Dutch,
+English (Australia), English (Belize), English (Canada), English (Caribbean),
+English (Ireland), English (Jamaica), English (New Zealand),
+English (Trinidad and Tobago), English (United Kingdom), Faroese, Finnish,
+French, Frisian, Galician, German, Greenlandic, Icelandic, Indonesian, Irish,
+isiXhosa, isiZulu, Italian, K'iche, Lower Sorbian, Luxembourgish, Malay,
+Mapudungun, Mohawk, Norwegian, Occitan, Portuguese, Quechua, Romansh, Sami,
+Scottish Gaelic, Sesotho sa Leboa, Setswana, Spanish, Swedish, Tamazight,
+Upper Sorbian, Welsh, Wolof
+T}
+852:T{
+Albanian, Bosnian (Latin), Croatian, Czech, Hungarian, Polish, Romanian,
+Serbian (Latin), Slovak, Slovenian, Turkmen
+T}
+855:Bosnian (Cyrillic), Serbian (Cyrillic)
+857:Azeri (Latin), Turkish, Uzbek (Latin)
+862:Hebrew (Israel)
+866:T{
+Azeri (Cyrillic), Bashkir, Belarusian, Bulgarian, Kyrgyz, Macedonian, Mongolian,
+Russian, Tajik, Tatar, Ukrainian, Uzbek (Cyrillic), Yakut
+T}
+874:Thai
+932:Japanese
+936:Chinese (Simplified)
+949:Korean (Korea)
+950:Chinese (Traditional)
+.TE
+.\" ----------------------------------------------------------------------------
 .SH SEE ALSO
 .BR fsck.fat (8),
 .BR mkfs.fat (8)

--- a/manpages/fatlabel.8.in
+++ b/manpages/fatlabel.8.in
@@ -47,6 +47,9 @@ similar) and must fit into 32 bits.
 Switch to volume ID mode.
 .IP "\fB\-r\fR, \fB\-\-reset\fR" 4
 Remove label in label mode or generate new ID in volume ID mode.
+.IP "\fB-c\fR \fIPAGE\fR, \fB\-\-codepage\fR=\fIPAGE\fR" 4
+Use DOS codepage \fIPAGE\fR to encode/decode label.
+By default codepage 850 is used.
 .IP "\fB\-h\fR, \fB\-\-help\fR" 4
 Display a help message and terminate.
 .IP "\fB\-V\fR, \fB\-\-version\fR" 4
@@ -78,7 +81,8 @@ label in both location.
 Since version 4.2, \fBfatlabel\fR reads a FAT label only from the root directory
 (like MS-DOS and Windows systems), but changes a FAT label in both locations. In
 version 4.2 was fixed handling of empty labels and labels which starts with a
-byte 0xE5.
+byte 0xE5. Also in this version was added support for non-ASCII labels according
+to specified DOS codepage.
 
 It is strongly suggested to not use \fBdosfslabel\fR prior to version 3.0.16.
 .\" ----------------------------------------------------------------------------

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -123,7 +123,7 @@ This is selected by default if \fBmkfs.fat\fR is run on 68k Atari Linux.
 Make read-only boot sector check.
 .IP "\fB-c\fR \fIPAGE\fR" 4
 Use DOS codepage \fIPAGE\fR to decode short file names.
-By default codepage 437 is used.
+By default codepage 850 is used.
 .IP "\fB\-d\fR \fIPATH\fR" 4
 Delete the specified file.
 If more than one file with that name exist, the first one is deleted.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,11 +20,13 @@ AM_CFLAGS = -Wall -Wextra -Wno-sign-compare -Wno-missing-field-initializers \
 sbin_PROGRAMS = fsck.fat mkfs.fat fatlabel
 noinst_PROGRAMS = testdevinfo
 
+charconv_common_sources = charconv.c charconv.h
 fscklabel_common_sources = boot.c boot.h common.c common.h \
 			   fat.c fat.h io.c io.h msdos_fs.h \
+			   $(charconv_common_sources) \
 			   fsck.fat.h endian_compat.h
 fsck_fat_SOURCES = check.c check.h file.c file.h fsck.fat.c \
-		   charconv.c charconv.h lfn.c lfn.h \
+		   lfn.c lfn.h \
 		   $(fscklabel_common_sources)
 fatlabel_SOURCES = fatlabel.c $(fscklabel_common_sources)
 

--- a/src/boot.c
+++ b/src/boot.c
@@ -38,6 +38,7 @@
 #include "io.h"
 #include "boot.h"
 #include "check.h"
+#include "charconv.h"
 
 #define ROUND_TO_MULTIPLE(n,m) ((n) && (m) ? (n)+(m)-1-((n)-1)%(m) : 0)
     /* don't divide by zero */
@@ -751,4 +752,26 @@ void remove_label(DOS_FS *fs)
 	de.attr = 0;
 	fs_write(offset, sizeof(DIR_ENT), &de);
     }
+}
+
+const char *pretty_label(const char *label)
+{
+    static char buffer[11*4+1];
+    char *p;
+    int i;
+    int last;
+
+    for (last = 10; last >= 0; last--) {
+        if (label[last] != ' ')
+            break;
+    }
+
+    p = buffer;
+    for (i = 0; i <= last && label[i]; ++i) {
+        if (!dos_char_to_printable(&p, label[i]))
+            *p++ = '_';
+    }
+    *p = 0;
+
+    return buffer;
 }

--- a/src/boot.h
+++ b/src/boot.h
@@ -31,6 +31,7 @@ void write_label(DOS_FS * fs, char *label);
 void remove_label(DOS_FS *fs);
 void write_serial(DOS_FS * fs, uint32_t serial);
 off_t find_volume_de(DOS_FS * fs, DIR_ENT * de);
+const char *pretty_label(const char *label);
 
 /* Reads the boot sector from the currently open device and initializes *FS */
 

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -7,8 +7,8 @@
 static iconv_t iconv_init_codepage(int codepage)
 {
     iconv_t result;
-    char codepage_name[16];
-    snprintf(codepage_name, sizeof(codepage_name), "CP%d", codepage);
+    char codepage_name[32];
+    snprintf(codepage_name, sizeof(codepage_name), "CP%d//TRANSLIT", codepage);
     result = iconv_open(nl_langinfo(CODESET), codepage_name);
     if (result == (iconv_t) - 1)
 	perror(codepage_name);

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -29,7 +29,7 @@ static int init_conversion(int codepage)
 	initialized = 1;
 	if (codepage < 0)
 	    codepage = DEFAULT_DOS_CODEPAGE;
-	setlocale(LC_ALL, "");	/* initialize locale */
+	setlocale(LC_CTYPE, "");	/* initialize locale for CODESET */
 	dos_to_local = iconv_init_codepage(codepage);
 	if (dos_to_local == (iconv_t) - 1 && codepage != DEFAULT_DOS_CODEPAGE) {
 	    printf("Trying to set fallback DOS codepage %d\n",

--- a/src/charconv.h
+++ b/src/charconv.h
@@ -1,7 +1,7 @@
 #ifndef _CHARCONV_H
 #define _CHARCONV_H
 
-#define DEFAULT_DOS_CODEPAGE 437
+#define DEFAULT_DOS_CODEPAGE 850
 
 int set_dos_codepage(int codepage);
 int dos_char_to_printable(char **p, unsigned char c);

--- a/src/charconv.h
+++ b/src/charconv.h
@@ -5,5 +5,6 @@
 
 int set_dos_codepage(int codepage);
 int dos_char_to_printable(char **p, unsigned char c);
+int local_string_to_dos_string(char *out, char *in, unsigned int len);
 
 #endif


### PR DESCRIPTION
* Initialize only LC_CTYPE locale
* Initialize iconv "from codepage" with //TRANSLIT
* fsck.fat: Change default DOS codepage to 850
* fatlabel: Add support for --codepage option
* manpages: Add section DOS CODEPAGES to fatlabel

See also: https://github.com/dosfstools/dosfstools/issues/66