### PR TITLE
fsck.fat: properly check for valid "." and ".." entries

### DIFF
--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -66,6 +66,9 @@ The start pointer is adjusted.
 Directory .. does not point to parent of parent directory.
 The start pointer is adjusted.
 .IP "\(bu" 4
+. and .. are not the two first entries in a non-root directory.
+The entries are created, moving occupied slots if necessary.
+.IP "\(bu" 4
 Start cluster number of a file is invalid.
 The file is truncated.
 .IP "\(bu" 4
@@ -89,8 +92,6 @@ They are marked as free.
 Additionally, the following problems are detected, but not repaired:
 .IP "\(bu" 4
 Invalid parameters in boot sector
-.IP "\(bu" 4
-Absence of . and .. entries in non-root directories
 .PP
 When \fBfsck.fat\fP checks a filesystem, it accumulates all changes in memory
 and performs them only after all checks are complete.
@@ -205,8 +206,6 @@ When recovering from a corrupted filesystem, \fBfsck.fat\fP dumps recovered data
 into files named \fIfsckNNNN.rec\fP in the top level directory of the filesystem.
 .\" ----------------------------------------------------------------------------
 .SH BUGS
-.IP "\(bu" 4
-Does not create . and .. files where necessary.
 .IP "\(bu" 4
 Does not remove entirely empty directories.
 .IP "\(bu" 4

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,8 +37,7 @@ TESTS = referenceFAT12.mkfs              \
 	label-fat32_xp_none.label
 
 
-XFAIL_TESTS = check-dot_entries.fsck \
-	      check-huge.fsck
+XFAIL_TESTS = check-huge.fsck
 
 TEST_EXTENSIONS = .mkfs .fsck .label
 MKFS_LOG_COMPILER = $(srcdir)/test-mkfs


### PR DESCRIPTION
This change makes fsck.fat check whether `.` and `..` entries exist in all non-root directories as the in two very first. If those entries are occupied by some other file, fsck.fat will offer to move them to some later slot. `.` and `..` entries found in any other slots are treated as ordinary bad-shortname entries. The test case for this situation has been enabled and verified to perform as expected.

The function `drop_file()` was also modified so that it does not mark dropped file clusters as free. This was necessary because otherwise dropping too-late `.` and `..` entries would delete their containing directory. If deleted entries' clusters are truly no longer used, they shall be picked up by a later reclamation stage.

Additionally, `subdirs()` and `check_file()` were modified not to check unused directory entries.

Merging this will resolve #32 fully.