### PR TITLE
fsck.fat: Fix dirty volume check

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -118,8 +118,8 @@ void read_fat(DOS_FS * fs)
     }
     if (second && memcmp(first, second, eff_size) != 0) {
 	FAT_ENTRY first_media, second_media;
-	get_fat(&first_media, first, 0, fs);
-	get_fat(&second_media, second, 0, fs);
+	get_fat(&first_media, first, 1, fs);
+	get_fat(&second_media, second, 1, fs);
 	first_ok = (first_media.value & FAT_EXTD(fs)) == FAT_EXTD(fs);
 	second_ok = (second_media.value & FAT_EXTD(fs)) == FAT_EXTD(fs);
 	if (first_ok && !second_ok) {


### PR DESCRIPTION
ClnShutBitMask and HrdErrBitMask bits are in the second cluster entry (FAT[1]). The first entry (FAT[0]) contains BPB_Media in its low 8 bits and all other bits are set to 1. Thus, fsck.fat never detected dirty volumes.

See https://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/fatgen103.doc, page 18.