### PR TITLE
[RFS] check.c: do lfn_remove  on auto_rename()

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -272,6 +272,8 @@ static void auto_rename(DOS_FILE * file)
 	sprintf(num, "%07lu", (unsigned long)number);
 	memcpy(file->dir_ent.name, "FSCK", 4);
 	memcpy(file->dir_ent.name + 4, num, 7);
+        if (file->lfn)
+           lfn_remove(file->lfn_offset, file->offset);
 	for (walk = first; walk; walk = walk->next)
 	    if (walk != file
 		&& !strncmp((const char *)walk->dir_ent.name,


### PR DESCRIPTION
I ran into the issues that I had a filesystem with two "uboot.env" files.

On closer inspection it become clear that the image contained a file called "FSCK0000.000" with the lfn (long-file-name) "uboot.env". The image also contains a "UBOOT.ENV" (as a regular FAT16 name). When this is mounted via the vfat kernel driver two "uboot.env" files appear. Which is confusing :) Mounting it as "msdos" helpered  to solve the mystery.

After looking at fsck.vfat I suspect that what happens is there was a corrupted entry for the uboot.env file which fsck.vfat corrected via auto_rename() in check.c. However this auto_rename() seems to only set the short filename. Any lfn-names remain untouched AFAICT. Which I suspect leads to the confusing result above.

Attached is a RFC patch that cleans the lfn name in auto_rename. I will try to find a way to properly test this, so far I was not successful with creating the right kind of corruption on the image.

Please check this carefully, I'm not familar with the internals of dosfstools but I would love to avoid that people run into the same confusion that I got into :)