### PR TITLE
Add automatic code page determination, based on $LC_ALL/$LC_CTYPE/$LANG.

### DIFF
--- a/manpages/fatlabel.8.in
+++ b/manpages/fatlabel.8.in
@@ -49,7 +49,7 @@ Switch to volume ID mode.
 Remove label in label mode or generate new ID in volume ID mode.
 .IP "\fB-c\fR \fIPAGE\fR, \fB\-\-codepage\fR=\fIPAGE\fR" 4
 Use DOS codepage \fIPAGE\fR to encode/decode label.
-By default codepage 850 is used.
+By default a codepage appropriate to your locale is used.
 .IP "\fB\-h\fR, \fB\-\-help\fR" 4
 Display a help message and terminate.
 .IP "\fB\-V\fR, \fB\-\-version\fR" 4
@@ -89,8 +89,8 @@ It is strongly suggested to not use \fBdosfslabel\fR prior to version 3.0.16.
 .SH DOS CODEPAGES
 MS-DOS and Windows systems uses DOS (OEM) codepage according to global Language
 Country/Region system settings. DOS codepage is needed for encoding/decoding
-non-ASCII FAT label. Default DOS codepage is 850. See following mapping table
-between DOS codepage and Language Country/Region:
+non-ASCII FAT label. See following mapping table between DOS codepage and
+Language Country/Region:
 .TS
 tab(:);
 c lx.

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -123,7 +123,7 @@ This is selected by default if \fBmkfs.fat\fR is run on 68k Atari Linux.
 Make read-only boot sector check.
 .IP "\fB-c\fR \fIPAGE\fR" 4
 Use DOS codepage \fIPAGE\fR to decode short file names.
-By default codepage 850 is used.
+By default a codepage appropriate to your locale is used.
 .IP "\fB\-d\fR \fIPATH\fR" 4
 Delete the specified file.
 If more than one file with that name exist, the first one is deleted.

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -3,6 +3,7 @@
 #include <langinfo.h>
 #include <locale.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 
@@ -34,12 +35,13 @@ static int init_conversion(int codepage)
     static int initialized = -1;
     if (initialized < 0) {
 	initialized = 1;
+	int defcp = default_dos_codepage();
 	if (codepage < 0)
-	    codepage = DEFAULT_DOS_CODEPAGE;
+	    codepage = defcp;
 	setlocale(LC_CTYPE, "");	/* initialize locale for CODESET */
 	if (!iconv_init_codepage(codepage, &dos_to_local, &local_to_dos)
-	    && codepage != DEFAULT_DOS_CODEPAGE) {
-	    codepage = DEFAULT_DOS_CODEPAGE;
+	    && codepage != defcp) {
+	    codepage = defcp;
 	    printf("Trying to set fallback DOS codepage %d\n",
 		   codepage);
 	    if (!iconv_init_codepage(codepage, &dos_to_local, &local_to_dos))
@@ -89,4 +91,96 @@ int local_string_to_dos_string(char *out, char *in, unsigned int len)
     }
     out[len-bytes_out] = 0;
     return 1;
+}
+
+struct code_mapping
+{
+    const char *lang;
+    int code_page;
+};
+
+int default_dos_codepage(void)
+{
+    /*
+     * Built from the list at:
+     * https://web.archive.org/web/20171015144140/https://www.microsoft.com/resources/msdn/goglobal/default.mspx
+     *
+     * Charsets in $LC_ALL/$LC_CTYPE/$LANG are disregarded. The only time that
+     * would ever matter is if the charset was ".cp<something>", which is
+     * basically never the case.
+     */
+
+    static const struct code_mapping code_map[] = {
+	{"ar", 720}, {"ba", 866}, {"be", 866}, {"bg", 866}, {"cs", 852},
+	{"el", 737}, {"et", 775}, {"fa", 720}, {"fil", 437}, {"ha", 437},
+	{"he", 862}, {"hr", 852}, {"hu", 852}, {"ig", 437}, {"iu", 437},
+	{"ja", 932}, {"kk", 866}, {"ko", 949}, {"ky", 866}, {"lt", 775},
+	{"lv", 775}, {"mk", 866}, {"mn", 866}, {"pl", 852}, {"prs", 720},
+	{"ro", 852}, {"ru", 866}, {"rw", 437}, {"sah", 866}, {"sk", 852},
+	{"sl", 852}, {"sq", 852}, {"sw", 437}, {"tg", 866}, {"th", 874},
+	{"tk", 852}, {"tr", 857}, {"tt", 866}, {"ug", 720}, {"uk", 866},
+	{"ur", 720}, {"vi", 1258}, {"yo", 437},
+	{"en_au", 850}, {"en_bz", 850}, {"en_ca", 850}, {"en_gb", 850},
+	{"en_ie", 850}, {"en_in", 437}, {"en_jm", 850}, {"en_my", 437},
+	{"en_nz", 850}, {"en_ph", 437}, {"en_sg", 437}, {"en_tt", 850},
+	{"en_us", 437}, {"en_za", 437}, {"en_zw", 437}, {"zh_cn", 936},
+	{"zh_hk", 950}, {"zh_mo", 950}, {"zh_sg", 936}, {"zh_tw", 950},
+	{"az@cyrillic", 866}, {"az@latin", 857}, {"bs@cyrillic", 855},
+	{"bs@latin", 852}, {"sr@cyrillic", 855}, {"sr@latin", 852},
+	{"uz@cyrillic", 866}, {"uz@latin", 857},
+	{"az", 857}, {"en", 437}, {"sr", 855}, {"uz", 857},
+    };
+
+    const char *lang;
+    unsigned i;
+
+    lang = getenv("LC_ALL");
+    if(!lang) {
+	lang = getenv("LC_CTYPE");
+	if(!lang) {
+	    lang = getenv("LANG");
+	    if (!lang)
+		lang = "";
+	}
+    }
+
+    static const char fields[] = "_@.";
+
+    for(i = 0; i != sizeof(code_map) / sizeof(*code_map); i++) {
+	const char *field = fields;
+	const char *p_lang = lang, *p_code = code_map[i].lang;
+
+	for(;;) {
+	    const char *n_lang = strchr(field, *p_lang);
+	    const char *n_code = strchr(field, *p_code);
+
+	    if ((n_lang || !*p_lang) && (n_code || !*p_code)) {
+		if (!*p_code)
+		    return code_map[i].code_page;
+		else if (!*p_lang)
+		    break;
+		else if (n_lang > n_code) {
+		    break;
+		} else if (n_lang < n_code) {
+		    while (*p_lang && !strchr(n_code, *p_lang))
+			p_lang++;
+		} else {
+		    p_code++;
+		    p_lang++;
+		}
+	    } else if (!n_lang && !n_code) {
+		char ch_lang = *p_lang;
+		if (ch_lang >= 'A' && ch_lang <= 'Z')
+		    ch_lang = ch_lang - 'A' + 'a';
+		if (ch_lang != *p_code)
+		    break;
+		p_lang++;
+		p_code++;
+	    } else {
+		break;
+	    }
+	}
+    }
+
+    return 850;
 }

--- a/src/charconv.h
+++ b/src/charconv.h
@@ -1,10 +1,9 @@
 #ifndef _CHARCONV_H
 #define _CHARCONV_H
 
-#define DEFAULT_DOS_CODEPAGE 850
-
 int set_dos_codepage(int codepage);
 int dos_char_to_printable(char **p, unsigned char c);
 int local_string_to_dos_string(char *out, char *in, unsigned int len);
+int default_dos_codepage(void);
 
 #endif

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -168,7 +168,7 @@ static void usage(int error, int usage_only)
     fprintf(f, "Options:\n");
     fprintf(f, "  -i, --volume-id     Work on serial number instead of label\n");
     fprintf(f, "  -r, --reset         Remove label or generate new serial number\n");
-    fprintf(f, "  -c N, --codepage=N  use DOS codepage N to encode/decode label (default: %d)\n", DEFAULT_DOS_CODEPAGE);
+    fprintf(f, "  -c N, --codepage=N  use DOS codepage N to encode/decode label (default: %d)\n", default_dos_codepage());
     fprintf(f, "  -V, --version       Show version number and terminate\n");
     fprintf(f, "  -h, --help          Print this message and terminate\n");
     exit(status);

--- a/src/fsck.fat.c
+++ b/src/fsck.fat.c
@@ -68,7 +68,7 @@ static void usage(char *name, int exitval)
     fprintf(stderr, "  -A              toggle Atari variant of the FAT filesystem\n");
     fprintf(stderr, "  -b              make read-only boot sector check\n");
     fprintf(stderr, "  -c N            use DOS codepage N to decode short file names (default: %d)\n",
-	    DEFAULT_DOS_CODEPAGE);
+	    default_dos_codepage());
     fprintf(stderr, "  -d PATH         drop file with name PATH (can be given multiple times)\n");
     fprintf(stderr, "  -f              salvage unused chains to files\n");
     fprintf(stderr, "  -l              list path names\n");


### PR DESCRIPTION
...Because I'm lazy, and I don't want to have to always be typing `-c 437`.

Semi-related observation: the [Windows OEM code pages](https://web.archive.org/web/20171015144140/https://www.microsoft.com/resources/msdn/goglobal/default.mspx) don't entirely match the [DOS code pages](https://web.archive.org/web/20140913235232/http://support.microsoft.com/kb/117850).

And for the record, [here's the script](https://gist.github.com/dmo2118/951790d439900da2819a9326c2ad20e9) that I used to generate the code page mappings.