### PR TITLE
mkfs.fat: Fix parsing and validation of numeric values

### DIFF
--- a/src/device_info.c
+++ b/src/device_info.c
@@ -44,6 +44,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <ctype.h>
 
 #include "blkdev.h"
 #include "device_info.h"
@@ -109,7 +111,7 @@ static int udev_fill_info(struct device_info *info, struct stat *stat)
     char holders_path[PATH_MAX + 1];
     DIR *holders_dir;
     struct dirent *dir_entry;
-    unsigned long number;
+    long number;
     char *endptr;
 
     if (device_info_verbose >= 3)
@@ -227,8 +229,9 @@ static int udev_fill_info(struct device_info *info, struct stat *stat)
 	if (device_info_verbose >= 3)
 	    printf("attribute \"partition\" is \"%s\"\n", attr);
 
-	number = strtoul(attr, &endptr, 10);
-	if (!*endptr)
+	errno = 0;
+	number = strtol(attr, &endptr, 10);
+	if (*attr && !isspace(*attr) && !*endptr && !errno && number >= 0 && number <= INT_MAX)
 	    info->partition = number;
     } else {
 	printf("attribute \"partition\" not found\n");

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <ctype.h>
 
 #include "common.h"
 #include "fsck.fat.h"
@@ -143,14 +144,14 @@ static void handle_volid(bool change, bool reset, const char *device, const char
 {
     DOS_FS fs = { 0 };
     char *tmp;
-    unsigned long long conversion;
+    long long conversion;
     uint32_t serial = 0;
 
     if (change) {
 	errno = 0;
-	conversion = strtoull(newserial, &tmp, 16);
+	conversion = strtoll(newserial, &tmp, 16);
 
-	if (!*newserial || *tmp) {
+	if (!*newserial || isspace(*newserial) || *tmp || conversion < 0) {
 	    fprintf(stderr, "fatlabel: volume ID must be a hexadecimal number\n");
 	    exit(1);
 	}

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -417,7 +417,7 @@ static void get_list_blocks(char *filename)
 {
     int i;
     FILE *listfile;
-    long blockno;
+    long long blockno;
     char *line = NULL;
     size_t linesize = 0;
     int lineno = 0;
@@ -439,9 +439,9 @@ static void get_list_blocks(char *filename)
 	}
 
 	errno = 0;
-	blockno = strtol(line, &end, 10);
+	blockno = strtoll(line, &end, 10);
 
-	if (errno) {
+	if (errno || blockno < 0) {
 	    fprintf(stderr,
 		    "While converting bad block number in line %d: %s\n",
 		    lineno, strerror(errno));
@@ -466,16 +466,16 @@ static void get_list_blocks(char *filename)
 
 	/* Mark all of the sectors in the block as bad */
 	for (i = 0; i < SECTORS_PER_BLOCK; i++) {
-	    unsigned long sector = blockno * SECTORS_PER_BLOCK + i;
+	    unsigned long long sector = blockno * SECTORS_PER_BLOCK + i;
 
 	    if (sector < start_data_sector) {
-		fprintf(stderr, "Block number %ld is before data area\n",
+		fprintf(stderr, "Block number %lld is before data area\n",
 			blockno);
 		die("Error in bad blocks file");
 	    }
 
 	    if (sector >= num_sectors) {
-		fprintf(stderr, "Block number %ld is behind end of filesystem\n",
+		fprintf(stderr, "Block number %lld is behind end of filesystem\n",
 			blockno);
 		die("Error in bad blocks file");
 	    }

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1353,6 +1353,7 @@ int main(int argc, char **argv)
     uint64_t cblocks = 0;
     int blocks_specified = 0;
     struct timeval create_timeval;
+    long long conversion;
 
     enum {OPT_HELP=1000, OPT_INVARIANT, OPT_VARIANT, OPT_CODEPAGE};
     const struct option long_options[] = {
@@ -1447,11 +1448,23 @@ int main(int argc, char **argv)
 	    break;
 
 	case 'i':		/* i : specify volume ID */
-	    volume_id = strtoul(optarg, &tmp, 16);
-	    if (*tmp) {
+	    errno = 0;
+	    conversion = strtoll(optarg, &tmp, 16);
+
+	    if (!*optarg || isspace(*optarg) || *tmp || conversion < 0) {
 		printf("Volume ID must be a hexadecimal number\n");
 		usage(argv[0], 1);
 	    }
+	    if (conversion > UINT32_MAX) {
+		printf("Volume ID does not fit in 32 bit\n");
+		usage(argv[0], 1);
+	    }
+	    if (errno) {
+		printf("Parsing volume ID failed (%s)\n", strerror(errno));
+		usage(argv[0], 1);
+	    }
+
+	    volume_id = conversion;
 	    break;
 
 	case 'l':		/* l : Bad block filename */

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1392,11 +1392,13 @@ int main(int argc, char **argv)
 	    break;
 
 	case 'b':		/* b : location of backup boot sector */
-	    backup_boot = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || backup_boot < 2 || backup_boot > 0xffff) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || conversion < 2 || conversion > 0xffff) {
 		printf("Bad location for backup boot sector : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    backup_boot = conversion;
 	    break;
 
 	case 'c':		/* c : Check FS as we build it */
@@ -1409,37 +1411,45 @@ int main(int argc, char **argv)
 	    break;
 
 	case 'D':		/* D : Choose Drive Number */
-	    drive_number_option = (int) strtol (optarg, &tmp, 0);
-	    if (*tmp || (drive_number_option != 0 && drive_number_option != 0x80)) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || (conversion != 0 && conversion != 0x80)) {
 		printf ("Drive number must be 0 or 0x80: %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    drive_number_option = conversion;
 	    drive_number_by_user=1;
 	    break;
 
 	case 'f':		/* f : Choose number of FATs */
-	    nr_fats = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || nr_fats < 1 || nr_fats > 4) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || conversion < 1 || conversion > 4) {
 		printf("Bad number of FATs : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    nr_fats = conversion;
 	    break;
 
 	case 'F':		/* F : Choose FAT size */
-	    size_fat = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || (size_fat != 12 && size_fat != 16 && size_fat != 32)) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || (conversion != 12 && conversion != 16 && conversion != 32)) {
 		printf("Bad FAT type : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    size_fat = conversion;
 	    size_fat_by_user = 1;
 	    break;
 
 	case 'h':		/* h : number of hidden sectors */
-	    hidden_sectors = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || hidden_sectors < 0) {
+	    errno = 0;
+	    conversion = strtoll(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || conversion < 0 || conversion > UINT32_MAX) {
 		printf("Bad number of hidden sectors : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    hidden_sectors = conversion;
 	    hidden_sectors_by_user = 1;
 	    break;
 
@@ -1533,15 +1543,17 @@ int main(int argc, char **argv)
 	    break;
 
 	case 'M':		/* M : FAT Media byte */
-	    fat_media_byte = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno) {
 		printf("Bad number for media descriptor : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
-	    if (fat_media_byte != 0xf0 && (fat_media_byte < 0xf8 || fat_media_byte > 0xff)) {
+	    if (conversion != 0xf0 && (conversion < 0xf8 || conversion > 0xff)) {
 		printf("FAT Media byte must either be between 0xF8 and 0xFF or be 0xF0 : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    fat_media_byte = conversion;
 	    break;
 
 	case 'n':		/* n : Volume name */
@@ -1553,44 +1565,48 @@ int main(int argc, char **argv)
 	    break;
 
 	case 'r':		/* r : Root directory entries */
-	    root_dir_entries = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || root_dir_entries < 16 || root_dir_entries > 32768) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || conversion < 16 || conversion > 32768) {
 		printf("Bad number of root directory entries : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    root_dir_entries = conversion;
 	    root_dir_entries_set = 1;
 	    break;
 
 	case 'R':		/* R : number of reserved sectors */
-	    reserved_sectors = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || reserved_sectors < 1 || reserved_sectors > 0xffff) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || conversion < 1 || conversion > 0xffff) {
 		printf("Bad number of reserved sectors : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    reserved_sectors = conversion;
 	    break;
 
 	case 's':		/* s : Sectors per cluster */
-	    sectors_per_cluster = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || (sectors_per_cluster != 1 && sectors_per_cluster != 2
-			 && sectors_per_cluster != 4 && sectors_per_cluster != 8
-			 && sectors_per_cluster != 16
-			 && sectors_per_cluster != 32
-			 && sectors_per_cluster != 64
-			 && sectors_per_cluster != 128)) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || (conversion != 1 && conversion != 2
+	        && conversion != 4 && conversion != 8 && conversion != 16
+	        && conversion != 32 && conversion != 64 && conversion != 128)) {
 		printf("Bad number of sectors per cluster : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    sectors_per_cluster = conversion;
 	    break;
 
 	case 'S':		/* S : Sector size */
-	    sector_size = (int)strtol(optarg, &tmp, 0);
-	    if (*tmp || (sector_size != 512 && sector_size != 1024 &&
-			 sector_size != 2048 && sector_size != 4096 &&
-			 sector_size != 8192 && sector_size != 16384 &&
-			 sector_size != 32768)) {
+	    errno = 0;
+	    conversion = strtol(optarg, &tmp, 0);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || (conversion != 512 && conversion != 1024 &&
+	        conversion != 2048 && conversion != 4096 && conversion != 8192 &&
+	        conversion != 16384 && conversion != 32768)) {
 		printf("Bad logical sector size : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
+	    sector_size = conversion;
 	    sector_size_set = 1;
 	    break;
 
@@ -1640,12 +1656,14 @@ int main(int argc, char **argv)
 
     if (optind != argc) {
 	blocks_specified = 1;
-	blocks = strtoull(argv[optind], &tmp, 0);
+	errno = 0;
+	conversion = strtoll(argv[optind], &tmp, 0);
 
-	if (*tmp) {
+	if (!*argv[optind] || isspace(*argv[optind]) || *tmp || errno || conversion < 0) {
 	    printf("Bad block count : %s\n", argv[optind]);
 	    usage(argv[0], 1);
 	}
+	blocks = conversion;
 
 	optind++;
     }


### PR DESCRIPTION
Properly handle errors from strtoul() function. To detect overflow/underflows it is needed to check for errno. Also there is a need to check special case if argument is empty string.