### PR TITLE
fsck.fat: Check and fix label

### DIFF
--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -86,6 +86,12 @@ filesystem check is restarted after truncation.
 File's cluster chain is shorter than indicated by the size fields.
 The file is truncated.
 .IP "\(bu" 4
+Volume label in root directory or label in boot sector is invalid.
+Invalid labels are removed.
+.IP "\(bu" 4
+Volume label in root directory and label in boot sector are different.
+Volume label from root directory is copied to boot sector.
+.IP "\(bu" 4
 Clusters are marked as used but are not owned by a file.
 They are marked as free.
 .PP
@@ -182,6 +188,14 @@ Try to undelete the specified file.
 \fBfsck.fat\fP tries to allocate a chain of contiguous unallocated clusters
 beginning with the start cluster of the undeleted file.
 This option can be given more than once.
+.IP "\fB\-U\fP" 4
+Consider lowercase volume and boot label as invalid and allow only uppercase
+characters.
+Such labels are forbidden by the FAT specification, but they are widely used
+by Linux tools.
+Moreover MS-DOS and Windows systems do not have problems to read them.
+Therefore volume and boot labels with lowercase characters are by default
+permitted.
 .IP "\fB\-v\fP" 4
 Verbose mode.
 Generates slightly more output.

--- a/src/boot.c
+++ b/src/boot.c
@@ -615,7 +615,7 @@ static void write_boot_label_or_serial(int label_mode, DOS_FS * fs,
     }
 }
 
-static void write_boot_label(DOS_FS * fs, const char *label)
+void write_boot_label(DOS_FS * fs, const char *label)
 {
     write_boot_label_or_serial(1, fs, label, 0);
 }
@@ -667,7 +667,7 @@ off_t find_volume_de(DOS_FS * fs, DIR_ENT * de)
     return 0;
 }
 
-static void write_volume_label(DOS_FS * fs, char *label)
+void write_volume_label(DOS_FS * fs, char *label)
 {
     time_t now;
     struct tm *mtime;

--- a/src/boot.h
+++ b/src/boot.h
@@ -28,6 +28,8 @@
 
 void read_boot(DOS_FS * fs);
 void write_label(DOS_FS * fs, char *label);
+void write_boot_label(DOS_FS * fs, const char *label);
+void write_volume_label(DOS_FS * fs, char *label);
 void remove_label(DOS_FS *fs);
 void write_serial(DOS_FS * fs, uint32_t serial);
 off_t find_volume_de(DOS_FS * fs, DIR_ENT * de);

--- a/src/charconv.h
+++ b/src/charconv.h
@@ -1,10 +1,14 @@
 #ifndef _CHARCONV_H
 #define _CHARCONV_H
 
+#include <stddef.h>
+
 #define DEFAULT_DOS_CODEPAGE 850
 
 int set_dos_codepage(int codepage);
 int dos_char_to_printable(char **p, unsigned char c, unsigned int out_size);
 int local_string_to_dos_string(char *out, char *in, unsigned int out_size);
+int dos_string_to_wchar_string(wchar_t *out, char *in, unsigned int out_size);
+int wchar_string_to_dos_string(char *out, wchar_t *in, unsigned int out_size);
 
 #endif

--- a/src/check.h
+++ b/src/check.h
@@ -31,4 +31,10 @@ int scan_root(DOS_FS * fs);
    for all the details. Returns a non-zero integer if the filesystem has to
    be checked again. */
 
+
+void check_label(DOS_FS * fs);
+
+/* Checks the volume label from the root directory entry that is valid and
+ * matches the label stored in boot sector. */
+
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -108,7 +108,7 @@ uint32_t generate_volume_id(void);
  * Generate a 32 bit volume ID
  */
 
-int validate_volume_label(wchar_t *wlabel, unsigned char *doslabel);
+int validate_volume_label(char *doslabel);
 
 /*
  * Validate volume label

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -90,7 +90,7 @@ static void handle_label(bool change, bool reset, const char *device, char *newl
 	ret = validate_volume_label(wlabel, (unsigned char *)label);
 	if (ret & 0x1) {
 	    fprintf(stderr,
-		    "fatlabel: warning - lowercase labels might not work properly with DOS or Windows\n");
+		    "fatlabel: warning - lowercase labels might not work properly on some systems\n");
 	}
 	if (ret & 0x2) {
 	    fprintf(stderr,

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -59,7 +59,6 @@ static void handle_label(bool change, bool reset, const char *device, char *newl
     DIR_ENT de;
 
     char label[12] = { 0 };
-    wchar_t wlabel[12] = { 0 };
     size_t len;
     int ret;
     int i;
@@ -69,11 +68,6 @@ static void handle_label(bool change, bool reset, const char *device, char *newl
 	if (len != (size_t)-1 && len > 11) {
 	    fprintf(stderr,
 		    "fatlabel: labels can be no longer than 11 characters\n");
-	    exit(1);
-	}
-
-	if (mbstowcs(wlabel, newlabel, 12) == (size_t)-1) {
-	    perror("fatlabel: error when processing label");
 	    exit(1);
 	}
 
@@ -87,7 +81,7 @@ static void handle_label(bool change, bool reset, const char *device, char *newl
 	    label[i] = ' ';
 	label[11] = 0;
 
-	ret = validate_volume_label(wlabel, (unsigned char *)label);
+	ret = validate_volume_label(label);
 	if (ret & 0x1) {
 	    fprintf(stderr,
 		    "fatlabel: warning - lowercase labels might not work properly on some systems\n");

--- a/src/fsck.fat.h
+++ b/src/fsck.fat.h
@@ -177,6 +177,7 @@ typedef struct {
 
 extern int rw, list, verbose, test, no_spaces_in_sfns;
 extern long fat_table;
+extern int only_uppercase_label;
 extern unsigned n_files;
 extern void *mem_queue;
 

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -658,7 +658,6 @@ static void setup_tables(void)
     struct msdos_volume_info *vi =
 	(size_fat == 32 ? &bs.fat32.vi : &bs.oldfat.vi);
     char label[12] = { 0 };
-    wchar_t wlabel[12] = { 0 };
     size_t len;
     int ret;
     int i;
@@ -708,9 +707,6 @@ static void setup_tables(void)
     if (len != (size_t)-1 && len > 11)
 	die("Label can be no longer than 11 characters");
 
-    if (mbstowcs(wlabel, volume_name, 12) == (size_t)-1)
-	pdie("Error when processing label");
-
     if (!local_string_to_dos_string(label, volume_name, 12))
 	die("Error when processing label");
 
@@ -721,7 +717,7 @@ static void setup_tables(void)
     if (memcmp(label, "           ", MSDOS_NAME) == 0)
 	memcpy(label, NO_NAME, MSDOS_NAME);
 
-    ret = validate_volume_label(wlabel, (unsigned char *)label);
+    ret = validate_volume_label(label);
     if (ret & 0x1)
 	fprintf(stderr,
 		"mkfs.fat: Warning: lowercase labels might not work properly on some systems\n");

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -724,7 +724,7 @@ static void setup_tables(void)
     ret = validate_volume_label(wlabel, (unsigned char *)label);
     if (ret & 0x1)
 	fprintf(stderr,
-		"mkfs.fat: Warning: lowercase labels might not work properly with DOS or Windows\n");
+		"mkfs.fat: Warning: lowercase labels might not work properly on some systems\n");
     if (ret & 0x2)
 	die("Labels with characters below 0x20 are not allowed\n");
     if (ret & 0x4)


### PR DESCRIPTION
Checks the volume label from the root directory entry that is valid and
matches the label stored in boot sector.