### PR TITLE
fsck.fat: Check for DOS Clean Shutdown bit

### DIFF
--- a/src/boot.h
+++ b/src/boot.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 
+void check_dirty_bits(DOS_FS * fs);
 void read_boot(DOS_FS * fs);
 void write_label(DOS_FS * fs, char *label);
 void remove_label(DOS_FS *fs);

--- a/src/fsck.fat.c
+++ b/src/fsck.fat.c
@@ -229,6 +229,8 @@ int main(int argc, char **argv)
 	reclaim_file(&fs);
     else
 	reclaim_free(&fs);
+    if (!atari_format)
+	check_dirty_bits(&fs);
     free_clusters = update_free(&fs);
     file_unused();
     qfree(&mem_queue);
@@ -238,6 +240,8 @@ int main(int argc, char **argv)
 	read_fat(&fs);
 	scan_root(&fs);
 	reclaim_free(&fs);
+	if (!atari_format)
+	    check_dirty_bits(&fs);
 	qfree(&mem_queue);
     }
     release_fat(&fs);

--- a/src/fsck.fat.h
+++ b/src/fsck.fat.h
@@ -39,6 +39,13 @@
 #define VFAT_LN_ATTR (ATTR_RO | ATTR_HIDDEN | ATTR_SYS | ATTR_VOLUME)
 
 #define FAT_STATE_DIRTY 0x01
+#define FAT_NEED_SURFACE_TEST 0x02
+
+#define FAT16_FLAG_HARDDISK_ERROR 0x4000
+#define FAT16_FLAG_CLEAN_SHUTDOWN 0x8000
+
+#define FAT32_FLAG_HARDDISK_ERROR 0x4000000
+#define FAT32_FLAG_CLEAN_SHUTDOWN 0x8000000
 
 /* ++roman: Use own definition of boot sector structure -- the kernel headers'
  * name for it is msdos_boot_sector in 2.0 and fat_boot_sector in 2.1 ... */
@@ -69,7 +76,7 @@ struct boot_sector {
     uint8_t reserved2[12];	/* Unused */
 
     uint8_t drive_number;	/* Logical Drive Number */
-    uint8_t reserved3;		/* Unused */
+    uint8_t boot_flags;		/* bit 0: dirty, bit 1: need surface test */
 
     uint8_t extended_sig;	/* Extended Signature (0x29) */
     uint32_t serial;		/* Serial number */
@@ -98,7 +105,7 @@ struct boot_sector_16 {
     uint32_t total_sect;	/* number of sectors (if sectors == 0) */
 
     uint8_t drive_number;	/* Logical Drive Number */
-    uint8_t reserved2;		/* Unused */
+    uint8_t boot_flags;		/* bit 0: dirty, bit 1: need surface test */
 
     uint8_t extended_sig;	/* Extended Signature (0x29) */
     uint32_t serial;		/* Serial number */

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -127,7 +127,7 @@ static inline int cdiv(int a, int b)
 
 struct msdos_volume_info {
     uint8_t drive_number;	/* BIOS drive number */
-    uint8_t RESERVED;		/* Unused */
+    uint8_t boot_flags;		/* bit 0: dirty, bit 1: need surface test */
     uint8_t ext_boot_sign;	/* 0x29 if fields below exist (DOS 3.3+) */
     uint8_t volume_id[4];	/* Volume ID number */
     uint8_t volume_label[11];	/* Volume label */


### PR DESCRIPTION
DOS Clean Shutdown bit in first reserved FAT entry is cleared when DOS or
Windows FAT driver mounts a volume and set is back when doing unmount.
Therefore set this bit when clearing FAT dirty bit in boot sector.

Fixes: #38