### PR TITLE
Fix memory leaks in read_fat() function

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -76,6 +76,16 @@ void get_fat(FAT_ENTRY * entry, void *fat, uint32_t cluster, DOS_FS * fs)
     }
 }
 
+void release_fat(DOS_FS * fs)
+{
+    if (fs->fat)
+	free(fs->fat);
+    if (fs->cluster_owner)
+	free(fs->cluster_owner);
+    fs->fat = NULL;
+    fs->cluster_owner = NULL;
+}
+
 /**
  * Build a bookkeeping structure from the partition's FAT table.
  * If the partition has multiple FATs and they don't agree, try to pick a winner,
@@ -93,12 +103,7 @@ void read_fat(DOS_FS * fs)
     uint32_t total_num_clusters;
 
     /* Clean up from previous pass */
-    if (fs->fat)
-	free(fs->fat);
-    if (fs->cluster_owner)
-	free(fs->cluster_owner);
-    fs->fat = NULL;
-    fs->cluster_owner = NULL;
+    release_fat(fs);
 
     total_num_clusters = fs->data_clusters + 2;
     eff_size = (total_num_clusters * fs->fat_bits + 7) / 8ULL;

--- a/src/fat.h
+++ b/src/fat.h
@@ -28,6 +28,11 @@ void read_fat(DOS_FS * fs);
 /* Loads the FAT of the filesystem described by FS. Initializes the FAT,
    replaces broken FATs and rejects invalid cluster entries. */
 
+void release_fat(DOS_FS * fs);
+
+/* Release the FAT of the filesystem described by FS and free allocated memory.
+   Call it after finish work with FAT. */
+
 void get_fat(FAT_ENTRY * entry, void *fat, uint32_t cluster, DOS_FS * fs);
 
 /* Retrieve the FAT entry (next chained cluster) for CLUSTER. */

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -123,6 +123,9 @@ static void handle_label(bool change, bool reset, const char *device, char *newl
 	    printf("%s\n", pretty_label((char *)de.name));
 	}
 
+	if (fs.fat_bits == 32)
+	    release_fat(&fs);
+
 	exit(0);
     }
 
@@ -130,6 +133,9 @@ static void handle_label(bool change, bool reset, const char *device, char *newl
 	write_label(&fs, label);
     else
 	remove_label(&fs);
+
+    if (fs.fat_bits == 32)
+	release_fat(&fs);
 }
 
 

--- a/src/fsck.fat.c
+++ b/src/fsck.fat.c
@@ -227,6 +227,7 @@ int main(int argc, char **argv)
 	reclaim_free(&fs);
 	qfree(&mem_queue);
     }
+    release_fat(&fs);
 
 exit:
     if (!write_immed && fs_changed()) {


### PR DESCRIPTION
Function read_fat() allocates memory to the user supplied buffer. Therefore
that function needs complement function for releasing allocated memory and
user needs to call if after finish its work.

This patch fixes memory leaks in fsck.fat and fatlabel tools.

Fixes #13