### PR TITLE
Use SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1455,7 +1455,6 @@ static void usage(const char *name, int exitval)
     fprintf(stderr, "  -v              Verbose execution\n");
     fprintf(stderr, "  --variant=TYPE  Select variant TYPE of filesystem (standard or Atari)\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "  --invariant     Use constants for randomly generated or time based values\n");
     fprintf(stderr, "  --offset=SECTOR Write the filesystem at a specific sector into the device file.\n");
     fprintf(stderr, "  --help          Show this help message and exit\n");
     exit(exitval);

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1074,7 +1074,7 @@ static void setup_tables(void)
         }
 
         /* If is not available then generate random 32 bit disk signature */
-        if (invariant)
+        if (invariant || getenv("SOURCE_DATE_EPOCH"))
             disk_sig = volume_id;
         else if (!disk_sig)
             disk_sig = generate_volume_id();
@@ -1287,7 +1287,7 @@ static void setup_tables(void)
 	    de->name[0] = 0x05;
 	de->attr = ATTR_VOLUME;
 	if (create_time != (time_t)-1) {
-	    if (!invariant)
+	    if (!invariant && !getenv("SOURCE_DATE_EPOCH"))
 		ctime = localtime(&create_time);
 	    else
 		ctime = gmtime(&create_time);
@@ -1477,6 +1477,7 @@ int main(int argc, char **argv)
     int blocks_specified = 0;
     struct timeval create_timeval;
     long long conversion;
+    char *source_date_epoch = NULL;
 
     enum {OPT_HELP=1000, OPT_INVARIANT, OPT_MBR, OPT_VARIANT, OPT_CODEPAGE, OPT_OFFSET};
     const struct option long_options[] = {
@@ -1497,8 +1498,20 @@ int main(int argc, char **argv)
 	    program_name = p + 1;
     }
 
-    if (gettimeofday(&create_timeval, NULL) == 0 && create_timeval.tv_sec != (time_t)-1)
+    source_date_epoch = getenv("SOURCE_DATE_EPOCH");
+    if (source_date_epoch) {
+        errno = 0;
+        conversion = strtoll(source_date_epoch, &tmp, 10);
+        create_time = conversion;
+        if (!isdigit((unsigned char)*source_date_epoch) || *tmp != '\0'
+                || errno != 0 || (long long)create_time != conversion) {
+            die("SOURCE_DATE_EPOCH is too big or contains non-digits: \"%s\"",
+                source_date_epoch);
+        }
+    } else if (gettimeofday(&create_timeval, NULL) == 0 && create_timeval.tv_sec != (time_t)-1) {
         create_time = create_timeval.tv_sec;
+    }
+
     volume_id = generate_volume_id();
     check_atari();
 

--- a/tests/test-mkfs
+++ b/tests/test-mkfs
@@ -52,7 +52,7 @@ echo "Test $testname"
 rm -f "${testname}.out" "${testname}.refimg"
 
 xxd -r "${srcdir}/${testname}.xxd" "${testname}.refimg" || exit 99
-run_mkfs -C -v --invariant $ARGS "${testname}.out" $SIZE || exit 99
+(export SOURCE_DATE_EPOCH=1426325213; run_mkfs -C -v -i 0x1234abcd $ARGS "${testname}.out" $SIZE) || exit 99
 
 echo
 echo "Comparing..."


### PR DESCRIPTION
Hi,

Here are some patches that implement reproducible builds with the SOURCE_DATE_EPOCH variable (in the context of dosfstools being used as part of builds).

I've run the test suite and it passes.