### PR TITLE
Fix formatting manpages

### DIFF
--- a/manpages/fatlabel.8.in
+++ b/manpages/fatlabel.8.in
@@ -20,16 +20,16 @@
 .\" can be found in /usr/share/common-licenses/GPL-3 file.
 .\"
 .\"
-.TH FATLABEL 8 2017\-10\-01 "dosfstools @PACKAGE_VERSION@"
+.TH FATLABEL 8 2017-10-01 "dosfstools @PACKAGE_VERSION@"
 .SH NAME
-fatlabel \- set or get MS\-DOS filesystem label or volume ID
+fatlabel \- set or get MS-DOS filesystem label or volume ID
 .\" ----------------------------------------------------------------------------
 .SH SYNOPSIS
 \fBfatlabel\fR [\fIOPTIONS\fR] \fIDEVICE\fR [\fINEW\fR]
 .\" ----------------------------------------------------------------------------
 .SH DESCRIPTION
 \fBfatlabel\fR will display or change the volume label or volume ID on the
-MS\-DOS filesystem located on \fIDEVICE\fR.
+MS-DOS filesystem located on \fIDEVICE\fR.
 By default it works in label mode.
 It can be switched to volume ID mode with the option \fB\-i\fR or
 \fB\-\-volume\-id\fR.
@@ -64,14 +64,14 @@ directory is interpreted as empty or none label, even if boot sector contains
 some valid label.
 
 When Windows XP or Windows 10 system changes a FAT label it stores it only in
-the root directory -- letting boot sector unchanged. Which leads to problems
+the root directory \(em letting boot sector unchanged. Which leads to problems
 when a label is removed on Windows. Old label is still stored in the boot sector
 but removed from the root directory.
 
 \fBdosfslabel\fR prior to the version 3.0.7 operated only with FAT labels stored
 in the boot sector, completely ignoring a volume label in the root directory.
 
-\fBdosfslabel\fR in versions 3.0.7 - 3.0.15 reads FAT labels from the root
+\fBdosfslabel\fR in versions 3.0.7\(en3.0.15 reads FAT labels from the root
 directory and in case of absence, it fallbacks to a label stored in the boot
 sector. Change operation resulted in updating a label in the boot sector and
 \fIsometimes\fR also in the root directory due to the bug. That bug was fixed in

--- a/manpages/fatlabel.8.in
+++ b/manpages/fatlabel.8.in
@@ -25,16 +25,16 @@
 fatlabel \- set or get MS-DOS filesystem label or volume ID
 .\" ----------------------------------------------------------------------------
 .SH SYNOPSIS
-\fBfatlabel\fR [\fIOPTIONS\fR] \fIDEVICE\fR [\fINEW\fR]
+\fBfatlabel\fP [\fIOPTIONS\fP] \fIDEVICE\fP [\fINEW\fP]
 .\" ----------------------------------------------------------------------------
 .SH DESCRIPTION
-\fBfatlabel\fR will display or change the volume label or volume ID on the
-MS-DOS filesystem located on \fIDEVICE\fR.
+\fBfatlabel\fP will display or change the volume label or volume ID on the
+MS-DOS filesystem located on \fIDEVICE\fP.
 By default it works in label mode.
-It can be switched to volume ID mode with the option \fB\-i\fR or
-\fB\-\-volume\-id\fR.
+It can be switched to volume ID mode with the option \fB\-i\fP or
+\fB\-\-volume\-id\fP.
 .PP
-If \fINEW\fR is omitted, then the existing label or volume ID is written to the
+If \fINEW\fP is omitted, then the existing label or volume ID is written to the
 standard output.
 A label can't be longer than 11 bytes and should be in all upper case for best
 compatibility.
@@ -43,16 +43,16 @@ A volume ID must be given as a hexadecimal number (no leading "0x" or
 similar) and must fit into 32 bits.
 .\" ----------------------------------------------------------------------------
 .SH OPTIONS
-.IP "\fB\-i\fR, \fB\-\-volume\-id\fR" 4
+.IP "\fB\-i\fP, \fB\-\-volume\-id\fP" 4
 Switch to volume ID mode.
-.IP "\fB\-r\fR, \fB\-\-reset\fR" 4
+.IP "\fB\-r\fP, \fB\-\-reset\fP" 4
 Remove label in label mode or generate new ID in volume ID mode.
-.IP "\fB-c\fR \fIPAGE\fR, \fB\-\-codepage\fR=\fIPAGE\fR" 4
-Use DOS codepage \fIPAGE\fR to encode/decode label.
+.IP "\fB-c\fP \fIPAGE\fP, \fB\-\-codepage\fP=\fIPAGE\fP" 4
+Use DOS codepage \fIPAGE\fP to encode/decode label.
 By default codepage 850 is used.
-.IP "\fB\-h\fR, \fB\-\-help\fR" 4
+.IP "\fB\-h\fP, \fB\-\-help\fP" 4
 Display a help message and terminate.
-.IP "\fB\-V\fR, \fB\-\-version\fR" 4
+.IP "\fB\-V\fP, \fB\-\-version\fP" 4
 Show version number and terminate.
 .\" ----------------------------------------------------------------------------
 .SH COMPATIBILITY and BUGS
@@ -68,23 +68,23 @@ the root directory \(em letting boot sector unchanged. Which leads to problems
 when a label is removed on Windows. Old label is still stored in the boot sector
 but removed from the root directory.
 
-\fBdosfslabel\fR prior to the version 3.0.7 operated only with FAT labels stored
+\fBdosfslabel\fP prior to the version 3.0.7 operated only with FAT labels stored
 in the boot sector, completely ignoring a volume label in the root directory.
 
-\fBdosfslabel\fR in versions 3.0.7\(en3.0.15 reads FAT labels from the root
+\fBdosfslabel\fP in versions 3.0.7\(en3.0.15 reads FAT labels from the root
 directory and in case of absence, it fallbacks to a label stored in the boot
 sector. Change operation resulted in updating a label in the boot sector and
-\fIsometimes\fR also in the root directory due to the bug. That bug was fixed in
-\fBdosfslabel\fR version 3.0.16 and since this version \fBdosfslabel\fR updates
+\fIsometimes\fP also in the root directory due to the bug. That bug was fixed in
+\fBdosfslabel\fP version 3.0.16 and since this version \fBdosfslabel\fP updates
 label in both location.
 
-Since version 4.2, \fBfatlabel\fR reads a FAT label only from the root directory
+Since version 4.2, \fBfatlabel\fP reads a FAT label only from the root directory
 (like MS-DOS and Windows systems), but changes a FAT label in both locations. In
 version 4.2 was fixed handling of empty labels and labels which starts with a
 byte 0xE5. Also in this version was added support for non-ASCII labels according
 to specified DOS codepage and were added checks if a new label is valid.
 
-It is strongly suggested to not use \fBdosfslabel\fR prior to version 3.0.16.
+It is strongly suggested to not use \fBdosfslabel\fP prior to version 3.0.16.
 .\" ----------------------------------------------------------------------------
 .SH DOS CODEPAGES
 MS-DOS and Windows systems use DOS (OEM) codepage for encoding and decoding FAT
@@ -96,7 +96,7 @@ mapping table between DOS codepage and Language for non-Unicode programs:
 .TS
 tab(:);
 c lx.
-\fBCodepage\fR:\fBLanguage\fR
+\fBCodepage\fP:\fBLanguage\fP
 437:T{
 English (India), English (Malaysia), English (Republic of the Philippines),
 English (Singapore), English (South Africa), English (United States),
@@ -141,13 +141,13 @@ T}
 .BR mkfs.fat (8)
 .\" ----------------------------------------------------------------------------
 .SH HOMEPAGE
-The home for the \fBdosfstools\fR project is its
+The home for the \fBdosfstools\fP project is its
 .UR https://github.com/dosfstools/dosfstools
 GitHub project page
 .UE .
 .\" ----------------------------------------------------------------------------
 .SH AUTHORS
-\fBdosfstools\fR were written by
+\fBdosfstools\fP were written by
 .MT werner.almesberger@\:lrc.di.epfl.ch
 Werner Almesberger
 .ME ,

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -24,10 +24,10 @@
 fsck.fat \- check and repair MS-DOS FAT filesystems
 .\" ----------------------------------------------------------------------------
 .SH SYNOPSIS
-\fBfsck.fat\fR [\fIOPTIONS\fR] \fIDEVICE\fR
+\fBfsck.fat\fP [\fIOPTIONS\fP] \fIDEVICE\fP
 .\" ----------------------------------------------------------------------------
 .SH DESCRIPTION
-\fBfsck.fat\fR verifies the consistency of MS-DOS filesystems and optionally
+\fBfsck.fat\fP verifies the consistency of MS-DOS filesystems and optionally
 tries to repair them.
 .PP
 The following filesystem problems can be corrected (in this order):
@@ -92,9 +92,9 @@ Invalid parameters in boot sector
 .IP "\(bu" 4
 Absence of . and .. entries in non-root directories
 .PP
-When \fBfsck.fat\fR checks a filesystem, it accumulates all changes in memory
+When \fBfsck.fat\fP checks a filesystem, it accumulates all changes in memory
 and performs them only after all checks are complete.
-This can be disabled with the \fB\-w\fR option.
+This can be disabled with the \fB\-w\fP option.
 .PP
 Two different variants of the FAT filesystem are supported.
 Standard is the FAT12, FAT16 and FAT32 filesystems as defined by Microsoft and
@@ -110,42 +110,42 @@ MS-DOS uses only 0xfff7 for bad clusters, where on Atari values 0xfff0\(en0xfff7
 are for this purpose (but the standard value is still 0xfff7).
 .\" ----------------------------------------------------------------------------
 .SH OPTIONS
-.IP "\fB\-a\fR" 4
+.IP "\fB\-a\fP" 4
 Automatically repair the filesystem.
 No user intervention is necessary.
 Whenever there is more than one method to solve a problem, the least
 destructive approach is used.
-.IP "\fB\-A\fR" 4
+.IP "\fB\-A\fP" 4
 Select using the Atari variation of the FAT filesystem if that isn't active
 already, otherwise select standard FAT filesystem.
-This is selected by default if \fBmkfs.fat\fR is run on 68k Atari Linux.
-.IP "\fB-b\fR" 4
+This is selected by default if \fBmkfs.fat\fP is run on 68k Atari Linux.
+.IP "\fB-b\fP" 4
 Make read-only boot sector check.
-.IP "\fB-c\fR \fIPAGE\fR" 4
-Use DOS codepage \fIPAGE\fR to decode short file names.
+.IP "\fB-c\fP \fIPAGE\fP" 4
+Use DOS codepage \fIPAGE\fP to decode short file names.
 By default codepage 850 is used.
-.IP "\fB\-d\fR \fIPATH\fR" 4
+.IP "\fB\-d\fP \fIPATH\fP" 4
 Delete the specified file.
 If more than one file with that name exist, the first one is deleted.
 This option can be given more than once.
-.IP "\fB\-f\fR" 4
+.IP "\fB\-f\fP" 4
 Salvage unused cluster chains to files.
 By default, unused clusters are added to the free disk space except in auto mode
-(\fB\-a\fR).
-.IP "\fB\-l\fR" 4
+(\fB\-a\fP).
+.IP "\fB\-l\fP" 4
 List path names of files being processed.
-.IP "\fB\-n\fR" 4
+.IP "\fB\-n\fP" 4
 No-operation mode: non-interactively check for errors, but don't write
 anything to the filesystem.
-.IP "\fB\-p\fR" 4
-Same as \fB\-a\fR, for compatibility with other *fsck.
-.IP "\fB\-r\fR" 4
+.IP "\fB\-p\fP" 4
+Same as \fB\-a\fP, for compatibility with other *fsck.
+.IP "\fB\-r\fP" 4
 Interactively repair the filesystem.
 The user is asked for advice whenever there is more than one approach to fix an
 inconsistency.
 This is the default mode and the option is only retained for backwards
 compatibility.
-.IP "\fB\-S\fR" 4
+.IP "\fB\-S\fP" 4
 Consider short (8.3) file names with spaces in the middle to be invalid, like
 previous versions of this program did.
 While such file names are not forbidden by the FAT specification, and were never
@@ -153,56 +153,56 @@ treated as errors by Microsoft file system checking tools, many DOS programs are
 unable to handle files with such names. Using this option can make them
 accessible to these programs.
 .IP "" 4
-Short file names which \fIstart\fR with a space are considered invalid
+Short file names which \fIstart\fP with a space are considered invalid
 regardless of this option's setting.
 .IP "" 4
-Previous versions of this program exceptionally treated \fIEA DATA . SF\fR and
-\fIWP ROOT . SF\fR as valid short names; using this option does not preserve
+Previous versions of this program exceptionally treated \fIEA DATA . SF\fP and
+\fIWP ROOT . SF\fP as valid short names; using this option does not preserve
 that exception.
-.IP "\fB\-t\fR" 4
+.IP "\fB\-t\fP" 4
 Mark unreadable clusters as bad.
-.IP "\fB\-u\fR \fIPATH\fR" 4
+.IP "\fB\-u\fP \fIPATH\fP" 4
 Try to undelete the specified file.
-\fBfsck.fat\fR tries to allocate a chain of contiguous unallocated clusters
+\fBfsck.fat\fP tries to allocate a chain of contiguous unallocated clusters
 beginning with the start cluster of the undeleted file.
 This option can be given more than once.
-.IP "\fB\-v\fR" 4
+.IP "\fB\-v\fP" 4
 Verbose mode.
 Generates slightly more output.
-.IP "\fB\-V\fR" 4
+.IP "\fB\-V\fP" 4
 Perform a verification pass.
 The filesystem check is repeated after the first run.
 The second pass should never report any fixable errors.
 It may take considerably longer than the first pass, because the first pass may
 have generated long list of modifications that have to be scanned for each disk
 read.
-.IP "\fB\-\-variant\fR \fITYPE\fR" 4
-Create a filesystem of variant \fITYPE\fR.
-Acceptable values are \fIstandard\fR and \fIatari\fR (in any combination of
+.IP "\fB\-\-variant\fP \fITYPE\fP" 4
+Create a filesystem of variant \fITYPE\fP.
+Acceptable values are \fIstandard\fP and \fIatari\fP (in any combination of
 upper/lower case).
 See above under DESCRIPTION for the differences.
-.IP "\fB\-w\fR" 4
+.IP "\fB\-w\fP" 4
 Write changes to disk immediately.
-.IP "\fB\-y\fR" 4
-Same as \fB\-a\fR (automatically repair filesystem) for compatibility with other
+.IP "\fB\-y\fP" 4
+Same as \fB\-a\fP (automatically repair filesystem) for compatibility with other
 fsck tools.
-.IP "\fB\-\-help\fR" 4
+.IP "\fB\-\-help\fP" 4
 Display help message describing usage and options then exit.
 .\" ----------------------------------------------------------------------------
 .SH "EXIT STATUS"
 .IP "0" 4
 No recoverable errors have been detected.
 .IP "1" 4
-Recoverable errors have been detected or \fBfsck.fat\fR has discovered an
+Recoverable errors have been detected or \fBfsck.fat\fP has discovered an
 internal inconsistency.
 .IP "2" 4
 Usage error.
-\fBfsck.fat\fR did not access the filesystem.
+\fBfsck.fat\fP did not access the filesystem.
 .\" ----------------------------------------------------------------------------
 .SH FILES
-.IP "\fIfsck0000.rec\fR, \fIfsck0001.rec\fR, ..." 4
-When recovering from a corrupted filesystem, \fBfsck.fat\fR dumps recovered data
-into files named \fIfsckNNNN.rec\fR in the top level directory of the filesystem.
+.IP "\fIfsck0000.rec\fP, \fIfsck0001.rec\fP, ..." 4
+When recovering from a corrupted filesystem, \fBfsck.fat\fP dumps recovered data
+into files named \fIfsckNNNN.rec\fP in the top level directory of the filesystem.
 .\" ----------------------------------------------------------------------------
 .SH BUGS
 .IP "\(bu" 4
@@ -219,13 +219,13 @@ Undeleting files should use a more sophisticated algorithm.
 .BR mkfs.fat (8)
 .\" ----------------------------------------------------------------------------
 .SH HOMEPAGE
-The home for the \fBdosfstools\fR project is its
+The home for the \fBdosfstools\fP project is its
 .UR https://github.com/dosfstools/dosfstools
 GitHub project page
 .UE .
 .\" ----------------------------------------------------------------------------
 .SH AUTHORS
-\fBdosfstools\fR were written by
+\fBdosfstools\fP were written by
 .MT werner.almesberger@\:lrc.di.epfl.ch
 Werner Almesberger
 .ME ,

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -19,15 +19,15 @@
 .\" can be found in /usr/share/common-licenses/GPL-3 file.
 .\"
 .\"
-.TH FSCK.FAT 8 2017\-06\-28 "dosfstools @PACKAGE_VERSION@"
+.TH FSCK.FAT 8 2017-06-28 "dosfstools @PACKAGE_VERSION@"
 .SH NAME
-fsck.fat \- check and repair MS\-DOS FAT filesystems
+fsck.fat \- check and repair MS-DOS FAT filesystems
 .\" ----------------------------------------------------------------------------
 .SH SYNOPSIS
 \fBfsck.fat\fR [\fIOPTIONS\fR] \fIDEVICE\fR
 .\" ----------------------------------------------------------------------------
 .SH DESCRIPTION
-\fBfsck.fat\fR verifies the consistency of MS\-DOS filesystems and optionally
+\fBfsck.fat\fR verifies the consistency of MS-DOS filesystems and optionally
 tries to repair them.
 .PP
 The following filesystem problems can be corrected (in this order):
@@ -45,7 +45,7 @@ This check is optional.
 Directories with a large number of bad entries (probably corrupt).
 The directory can be deleted.
 .IP "*" 4
-Files . and .. are non\-directories.
+Files . and .. are non-directories.
 They can be deleted or renamed.
 .IP "*" 4
 Directories . and .. in root directory.
@@ -57,7 +57,7 @@ They can be renamed.
 Duplicate directory entries.
 They can be deleted or renamed.
 .IP "*" 4
-Directories with non\-zero size field.
+Directories with non-zero size field.
 Size is set to zero.
 .IP "*" 4
 Directory . does not point to parent directory.
@@ -90,7 +90,7 @@ Additionally, the following problems are detected, but not repaired:
 .IP "*" 4
 Invalid parameters in boot sector
 .IP "*" 4
-Absence of . and .. entries in non\-root directories
+Absence of . and .. entries in non-root directories
 .PP
 When \fBfsck.fat\fR checks a filesystem, it accumulates all changes in memory
 and performs them only after all checks are complete.
@@ -103,10 +103,10 @@ The other is the legacy Atari variant used on Atari ST.
 .PP
 There are some minor differences in Atari format:
 Some boot sector fields are interpreted slightly different, and the special FAT
-entries for end\-of\-file and bad cluster can be different.
-Under MS\-DOS 0xfff8 is used for EOF and Atari employs 0xffff by default, but
-both systems recognize all values from 0xfff8...0xffff as end\-of\-file.
-MS\-DOS uses only 0xfff7 for bad clusters, where on Atari values 0xfff0...0xfff7
+entries for end-of-file and bad cluster can be different.
+Under MS-DOS 0xfff8 is used for EOF and Atari employs 0xffff by default, but
+both systems recognize all values from 0xfff8\(en0xffff as end-of-file.
+MS-DOS uses only 0xfff7 for bad clusters, where on Atari values 0xfff0\(en0xfff7
 are for this purpose (but the standard value is still 0xfff7).
 .\" ----------------------------------------------------------------------------
 .SH OPTIONS
@@ -135,7 +135,7 @@ By default, unused clusters are added to the free disk space except in auto mode
 .IP "\fB\-l\fR" 4
 List path names of files being processed.
 .IP "\fB\-n\fR" 4
-No\-operation mode: non\-interactively check for errors, but don't write
+No-operation mode: non-interactively check for errors, but don't write
 anything to the filesystem.
 .IP "\fB\-p\fR" 4
 Same as \fB\-a\fR, for compatibility with other *fsck.

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -31,65 +31,65 @@ fsck.fat \- check and repair MS-DOS FAT filesystems
 tries to repair them.
 .PP
 The following filesystem problems can be corrected (in this order):
-.IP "*" 4
+.IP "\(bu" 4
 FAT contains invalid cluster numbers.
 Cluster is changed to EOF.
-.IP "*" 4
+.IP "\(bu" 4
 File's cluster chain contains a loop.
 The loop is broken.
-.IP "*" 4
+.IP "\(bu" 4
 Bad clusters (read errors).
 The clusters are marked bad and they are removed from files owning them.
 This check is optional.
-.IP "*" 4
+.IP "\(bu" 4
 Directories with a large number of bad entries (probably corrupt).
 The directory can be deleted.
-.IP "*" 4
+.IP "\(bu" 4
 Files . and .. are non-directories.
 They can be deleted or renamed.
-.IP "*" 4
+.IP "\(bu" 4
 Directories . and .. in root directory.
 They are deleted.
-.IP "*" 4
+.IP "\(bu" 4
 Bad filenames.
 They can be renamed.
-.IP "*" 4
+.IP "\(bu" 4
 Duplicate directory entries.
 They can be deleted or renamed.
-.IP "*" 4
+.IP "\(bu" 4
 Directories with non-zero size field.
 Size is set to zero.
-.IP "*" 4
+.IP "\(bu" 4
 Directory . does not point to parent directory.
 The start pointer is adjusted.
-.IP "*" 4
+.IP "\(bu" 4
 Directory .. does not point to parent of parent directory.
 The start pointer is adjusted.
-.IP "*" 4
+.IP "\(bu" 4
 Start cluster number of a file is invalid.
 The file is truncated.
-.IP "*" 4
+.IP "\(bu" 4
 File contains bad or free clusters.
 The file is truncated.
-.IP "*" 4
+.IP "\(bu" 4
 File's cluster chain is longer than indicated by the size fields.
 The file is truncated.
-.IP "*" 4
+.IP "\(bu" 4
 Two or more files share the same cluster(s).
 All but one of the files are truncated.
 If the file being truncated is a directory file that has already been read, the
 filesystem check is restarted after truncation.
-.IP "*" 4
+.IP "\(bu" 4
 File's cluster chain is shorter than indicated by the size fields.
 The file is truncated.
-.IP "*" 4
+.IP "\(bu" 4
 Clusters are marked as used but are not owned by a file.
 They are marked as free.
 .PP
 Additionally, the following problems are detected, but not repaired:
-.IP "*" 4
+.IP "\(bu" 4
 Invalid parameters in boot sector
-.IP "*" 4
+.IP "\(bu" 4
 Absence of . and .. entries in non-root directories
 .PP
 When \fBfsck.fat\fR checks a filesystem, it accumulates all changes in memory
@@ -205,9 +205,13 @@ When recovering from a corrupted filesystem, \fBfsck.fat\fR dumps recovered data
 into files named \fIfsckNNNN.rec\fR in the top level directory of the filesystem.
 .\" ----------------------------------------------------------------------------
 .SH BUGS
+.IP "\(bu" 4
 Does not create . and .. files where necessary.
+.IP "\(bu" 4
 Does not remove entirely empty directories.
+.IP "\(bu" 4
 Should give more diagnostic messages.
+.IP "\(bu" 4
 Undeleting files should use a more sophisticated algorithm.
 .\" ----------------------------------------------------------------------------
 .SH SEE ALSO

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -156,8 +156,8 @@ accessible to these programs.
 Short file names which \fIstart\fP with a space are considered invalid
 regardless of this option's setting.
 .IP "" 4
-Previous versions of this program exceptionally treated \fIEA DATA . SF\fP and
-\fIWP ROOT . SF\fP as valid short names; using this option does not preserve
+Previous versions of this program exceptionally treated \fIEA DATA. SF\fP and
+\fIWP ROOT. SF\fP as valid short names; using this option does not preserve
 that exception.
 .IP "\fB\-t\fP" 4
 Mark unreadable clusters as bad.

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -156,9 +156,9 @@ accessible to these programs.
 Short file names which \fIstart\fR with a space are considered invalid
 regardless of this option's setting.
 .IP "" 4
-Previous versions of this program exceptionally treated "EA DATA . SF" and
-"WP ROOT . SF" as valid short names; using this option does not preserve that
-exception.
+Previous versions of this program exceptionally treated \fIEA DATA . SF\fR and
+\fIWP ROOT . SF\fR as valid short names; using this option does not preserve
+that exception.
 .IP "\fB\-t\fR" 4
 Mark unreadable clusters as bad.
 .IP "\fB\-u\fR \fIPATH\fR" 4
@@ -178,8 +178,8 @@ have generated long list of modifications that have to be scanned for each disk
 read.
 .IP "\fB\-\-variant\fR \fITYPE\fR" 4
 Create a filesystem of variant \fITYPE\fR.
-Acceptable values are 'standard' and 'atari' (in any combination of upper/lower
-case).
+Acceptable values are \fIstandard\fR and \fIatari\fR (in any combination of
+upper/lower case).
 See above under DESCRIPTION for the differences.
 .IP "\fB\-w\fR" 4
 Write changes to disk immediately.
@@ -200,9 +200,9 @@ Usage error.
 \fBfsck.fat\fR did not access the filesystem.
 .\" ----------------------------------------------------------------------------
 .SH FILES
-.IP "fsck0000.rec, fsck0001.rec, ..." 4
+.IP "\fIfsck0000.rec\fR, \fIfsck0001.rec\fR, ..." 4
 When recovering from a corrupted filesystem, \fBfsck.fat\fR dumps recovered data
-into files named 'fsckNNNN.rec' in the top level directory of the filesystem.
+into files named \fIfsckNNNN.rec\fR in the top level directory of the filesystem.
 .\" ----------------------------------------------------------------------------
 .SH BUGS
 Does not create . and .. files where necessary.

--- a/manpages/mkfs.fat.8.in
+++ b/manpages/mkfs.fat.8.in
@@ -20,9 +20,9 @@
 .\" can be found in /usr/share/common-licenses/GPL-3 file.
 .\"
 .\"
-.TH MKFS.FAT 8 2017\-10\-01 "dosfstools @PACKAGE_VERSION@"
+.TH MKFS.FAT 8 2017-10-01 "dosfstools @PACKAGE_VERSION@"
 .SH NAME
-mkfs.fat \- create an MS\-DOS FAT filesystem
+mkfs.fat \- create an MS-DOS FAT filesystem
 .\" ----------------------------------------------------------------------------
 .SH SYNOPSIS
 \fBmkfs.fat\fR [\fIOPTIONS\fR] \fIDEVICE\fR [\fIBLOCK-COUNT\fR]

--- a/manpages/mkfs.fat.8.in
+++ b/manpages/mkfs.fat.8.in
@@ -124,7 +124,7 @@ filesystem on a device with partitions or virtual mapping.
 This is different when using MO disks.
 One doesn't always need partitions on MO disks.
 The filesystem can go directly to the whole disk.
-Under other OSes this is known as the 'superfloppy' format.
+Under other OSes this is known as the \fIsuperfloppy\fR format.
 This switch will force \fBmkfs.fat\fR to work properly.
 .IP "\fB\-l\fR \fIFILENAME\fR" 4
 Read the bad blocks list from \fIFILENAME\fR.
@@ -181,8 +181,8 @@ This is useful for creating a filesystem in a partitioned disk image without
 having to set up a loop device.
 .IP "\fB\-\-variant\fR \fITYPE\fR" 4
 Create a filesystem of variant \fITYPE\fR.
-Acceptable values are 'standard' and 'atari' (in any combination of upper/lower
-case).
+Acceptable values are \fIstandard\fR and \fIatari\fR (in any combination of
+upper/lower case).
 See above under DESCRIPTION for the differences.
 .IP "\fB\-\-help\fR" 4
 Display option summary and exit.

--- a/manpages/mkfs.fat.8.in
+++ b/manpages/mkfs.fat.8.in
@@ -25,18 +25,18 @@
 mkfs.fat \- create an MS-DOS FAT filesystem
 .\" ----------------------------------------------------------------------------
 .SH SYNOPSIS
-\fBmkfs.fat\fR [\fIOPTIONS\fR] \fIDEVICE\fR [\fIBLOCK-COUNT\fR]
+\fBmkfs.fat\fP [\fIOPTIONS\fP] \fIDEVICE\fP [\fIBLOCK-COUNT\fP]
 .\" ----------------------------------------------------------------------------
 .SH DESCRIPTION
-\fBmkfs.fat\fR is used to create a FAT filesystem on a device or in an image
+\fBmkfs.fat\fP is used to create a FAT filesystem on a device or in an image
 file.
-\fIDEVICE\fR is the special file corresponding to the device (e.g. /dev/sdXX) or
-the image file (which does not need to exist when the option \fB-C\fR is given).
-\fIBLOCK-COUNT\fR is the number of blocks on the device and size of one block is
+\fIDEVICE\fP is the special file corresponding to the device (e.g. /dev/sdXX) or
+the image file (which does not need to exist when the option \fB-C\fP is given).
+\fIBLOCK-COUNT\fP is the number of blocks on the device and size of one block is
 always 1024 bytes, independently of the sector size or the cluster size.
-Therefore \fIBLOCK-COUNT\fR specifies size of filesystem in KiB unit and not in
-the number of sectors (like for all other \fBmkfs.fat\fR options).
-If omitted, \fBmkfs.fat\fR automatically chooses a filesystem size to fill the
+Therefore \fIBLOCK-COUNT\fP specifies size of filesystem in KiB unit and not in
+the number of sectors (like for all other \fBmkfs.fat\fP options).
+If omitted, \fBmkfs.fat\fP automatically chooses a filesystem size to fill the
 available space.
 .PP
 Two different variants of the FAT filesystem are supported.
@@ -44,7 +44,7 @@ Standard is the FAT12, FAT16 and FAT32 filesystems as defined by Microsoft and
 widely used on hard disks and removable media like USB sticks and SD cards.
 The other is the legacy Atari variant used on Atari ST.
 .PP
-In Atari mode, if not directed otherwise by the user, \fBmkfs.fat\fR will
+In Atari mode, if not directed otherwise by the user, \fBmkfs.fat\fP will
 always use 2 sectors per cluster, since GEMDOS doesn't like other values very
 much.
 It will also obey the maximum number of sectors GEMDOS can handle.
@@ -52,36 +52,36 @@ Larger filesystems are managed by raising the logical sector size.
 An Atari-compatible serial number for the filesystem is generated, and a 12 bit
 FAT is used only for filesystems that have one of the usual floppy sizes (720k,
 1.2M, 1.44M, 2.88M), a 16 bit FAT otherwise.
-This can be overridden with the \fB\-F\fR option.
+This can be overridden with the \fB\-F\fP option.
 Some PC-specific boot sector fields aren't written, and a boot message (option
-\fB\-m\fR) is ignored.
+\fB\-m\fP) is ignored.
 .\" ----------------------------------------------------------------------------
 .SH OPTIONS
-.IP "\fB\-a\fR" 4
-Normally, for any filesystem except very small ones, \fBmkfs.fat\fR will align
+.IP "\fB\-a\fP" 4
+Normally, for any filesystem except very small ones, \fBmkfs.fat\fP will align
 all the data structures to cluster size, to make sure that as long as the
 partition is properly aligned, so will all the data structures in the
 filesystem.
 This option disables alignment; this may provide a handful of additional
 clusters of storage at the expense of a significant performance degradation on
 RAIDs, flash media or large-sector hard disks.
-.IP "\fB\-A\fR" 4
+.IP "\fB\-A\fP" 4
 Select using the Atari variation of the FAT filesystem if that isn't active
 already, otherwise select standard FAT filesystem.
-This is selected by default if \fBmkfs.fat\fR is run on 68k Atari Linux.
-.IP "\fB\-b\fR \fISECTOR-OF-BACKUP\fR" 4
+This is selected by default if \fBmkfs.fat\fP is run on 68k Atari Linux.
+.IP "\fB\-b\fP \fISECTOR-OF-BACKUP\fP" 4
 Selects the location of the backup boot sector for FAT32.
 Default depends on number of reserved sectors, but usually is sector 6.
 The backup must be within the range of reserved sectors.
 .IP "\fB\-c" 4
 Check the device for bad blocks before creating the filesystem.
-.IP "\fB\-C\fR" 4
-Create the file given as \fIDEVICE\fR on the command line, and write the
+.IP "\fB\-C\fP" 4
+Create the file given as \fIDEVICE\fP on the command line, and write the
 to-be-created filesystem to it.
 This can be used to create the new filesystem in a file instead of on a real
-device, and to avoid using \fBdd\fR in advance to create a file of appropriate
+device, and to avoid using \fBdd\fP in advance to create a file of appropriate
 size.
-With this option, the \fIBLOCK-COUNT\fR must be given, because otherwise the
+With this option, the \fIBLOCK-COUNT\fP must be given, because otherwise the
 intended size of the filesystem wouldn't be known.
 The file created is a sparse file, which actually only contains the meta-data
 areas (boot sector, FATs, and root directory).
@@ -89,18 +89,18 @@ The data portions won't be stored on the disk, but the file nevertheless will
 have the correct size.
 The resulting file can be copied later to a floppy disk or other device, or
 mounted through a loop device.
-.IP "\fB\-D\fR \fIDRIVE-NUMBER\fR" 4
+.IP "\fB\-D\fP \fIDRIVE-NUMBER\fP" 4
 Specify the BIOS drive number to be stored in the FAT boot sector.
 This value is usually 0x80 for hard disks and 0x00 for floppy devices or
 partitions to be used for floppy emulation.
-.IP "\fB\-f\fR \fINUMBER-OF-FATS\fR" 4
+.IP "\fB\-f\fP \fINUMBER-OF-FATS\fP" 4
 Specify the number of file allocation tables in the filesystem.
 The default is 2.
-.IP "\fB\-F\fR \fIFAT-SIZE\fR" 4
+.IP "\fB\-F\fP \fIFAT-SIZE\fP" 4
 Specifies the type of file allocation tables used (12, 16 or 32 bit).
-If nothing is specified, \fBmkfs.fat\fR will automatically select between 12, 16
+If nothing is specified, \fBmkfs.fat\fP will automatically select between 12, 16
 and 32 bit, whatever fits better for the filesystem size.
-.IP "\fB\-h\fR \fINUMBER-OF-HIDDEN-SECTORS\fR" 4
+.IP "\fB\-h\fP \fINUMBER-OF-HIDDEN-SECTORS\fP" 4
 Specify the number of so-called \fIhidden sectors\fP, as stored in the FAT boot
 sector: this number represents the beginning sector of the partition containing
 the file system. Normally this is an offset (in sectors) relative to the start
@@ -113,28 +113,28 @@ ignore it.
 By default, if the \fIDEVICE\fP is a partition block device, \fBmkfs.fat\fP uses
 the partition offset relative to disk start. Otherwise, \fBmkfs.fat\fP assumes
 zero. Use this option to override this behaviour.
-.IP "\fB\-i\fR \fIVOLUME-ID\fR" 4
-Sets the volume ID of the newly created filesystem; \fIVOLUME-ID\fR is a 32-bit
+.IP "\fB\-i\fP \fIVOLUME-ID\fP" 4
+Sets the volume ID of the newly created filesystem; \fIVOLUME-ID\fP is a 32-bit
 hexadecimal number (for example, 2e24ec82).
 The default is a number which depends on the filesystem creation time.
-.IP "\fB\-I\fR" 4
+.IP "\fB\-I\fP" 4
 Ignore and disable safety checks. By default \fBmkfs.fat\fP refuses to create a
 filesystem on a device with partitions or virtual mapping.
-\fBmkfs.fat\fR will complain and tell you that it refuses to work.
+\fBmkfs.fat\fP will complain and tell you that it refuses to work.
 This is different when using MO disks.
 One doesn't always need partitions on MO disks.
 The filesystem can go directly to the whole disk.
-Under other OSes this is known as the \fIsuperfloppy\fR format.
-This switch will force \fBmkfs.fat\fR to work properly.
-.IP "\fB\-l\fR \fIFILENAME\fR" 4
-Read the bad blocks list from \fIFILENAME\fR.
-.IP "\fB\-m\fR \fIMESSAGE-FILE\fR" 4
+Under other OSes this is known as the \fIsuperfloppy\fP format.
+This switch will force \fBmkfs.fat\fP to work properly.
+.IP "\fB\-l\fP \fIFILENAME\fP" 4
+Read the bad blocks list from \fIFILENAME\fP.
+.IP "\fB\-m\fP \fIMESSAGE-FILE\fP" 4
 Sets the message the user receives on attempts to boot this filesystem without
 having properly installed an operating system.
 The message file must not exceed 418 bytes once line feeds have been converted
 to carriage return-line feed combinations, and tabs have been expanded.
 If the filename is a hyphen (-), the text is taken from standard input.
-.IP "\fB\-M\fR \fIFAT-MEDIA-TYPE\fR" 4
+.IP "\fB\-M\fP \fIFAT-MEDIA-TYPE\fP" 4
 Specify the media type to be stored in the FAT boot sector.
 This value is usually 0xF8 for hard disks and is 0xF0 or a value from 0xF9 to
 0xFF for floppies or partitions to be used for floppy emulation.
@@ -147,70 +147,70 @@ overlaps with the end of the first FAT sector (boot code location), therefore
 there is no additional space usage. Default is \fIauto\fP mode in which
 \fBmkfs.fat\fP put MBR table only for non-removable disks when formatting
 whole unpartitioned disk.
-.IP "\fB\-n\fR \fIVOLUME-NAME\fR" 4
+.IP "\fB\-n\fP \fIVOLUME-NAME\fP" 4
 Sets the volume name (label) of the filesystem.
 The volume name can be up to 11 characters long.
 Supplying an empty string, a string consisting only of white space or the
-string "NO NAME" as \fIVOLUME-NAME\fR has the same effect as not giving the
-\fB\-n\fR option.
+string "NO NAME" as \fIVOLUME-NAME\fP has the same effect as not giving the
+\fB\-n\fP option.
 The default is no label.
-.IP "\fB\-\-codepage\fR=\fIPAGE\fR" 4
-Use DOS codepage \fIPAGE\fR to encode label.
+.IP "\fB\-\-codepage\fP=\fIPAGE\fP" 4
+Use DOS codepage \fIPAGE\fP to encode label.
 By default codepage 850 is used.
-.IP "\fB\-r\fR \fIROOT-DIR-ENTRIES\fR" 4
+.IP "\fB\-r\fP \fIROOT-DIR-ENTRIES\fP" 4
 Select the number of entries available in the root directory.
 The default is 112 or 224 for floppies and 512 for hard disks.
-.IP "\fB\-R\fR \fINUMBER-OF-RESERVED-SECTORS\fR" 4
+.IP "\fB\-R\fP \fINUMBER-OF-RESERVED-SECTORS\fP" 4
 Select the number of reserved sectors.
 With FAT32 format at least 2 reserved sectors are needed, the default is 32.
 Otherwise the default is 1 (only the boot sector).
-.IP "\fB\-s\fR \fISECTORS-PER-CLUSTER\fR" 4
+.IP "\fB\-s\fP \fISECTORS-PER-CLUSTER\fP" 4
 Specify the number of disk sectors per cluster.
 Must be a power of 2, i.e. 1, 2, 4, 8, ... 128.
-.IP "\fB\-S\fR \fILOGICAL-SECTOR-SIZE\fR" 4
+.IP "\fB\-S\fP \fILOGICAL-SECTOR-SIZE\fP" 4
 Specify the number of bytes per logical sector.
 Must be a power of 2 and greater than or equal to 512, i.e. 512, 1024, 2048,
 4096, 8192, 16384, or 32768.
 Values larger than 4096 are not conforming to the FAT file system specification
 and may not work everywhere.
-.IP "\fB\-v\fR" 4
+.IP "\fB\-v\fP" 4
 Verbose execution.
-.IP "\fB\-\-offset\fR \fISECTOR\fR" 4
+.IP "\fB\-\-offset\fP \fISECTOR\fP" 4
 Write the filesystem at a specific sector into the device file.
 This is useful for creating a filesystem in a partitioned disk image without
 having to set up a loop device.
-.IP "\fB\-\-variant\fR \fITYPE\fR" 4
-Create a filesystem of variant \fITYPE\fR.
-Acceptable values are \fIstandard\fR and \fIatari\fR (in any combination of
+.IP "\fB\-\-variant\fP \fITYPE\fP" 4
+Create a filesystem of variant \fITYPE\fP.
+Acceptable values are \fIstandard\fP and \fIatari\fP (in any combination of
 upper/lower case).
 See above under DESCRIPTION for the differences.
-.IP "\fB\-\-help\fR" 4
+.IP "\fB\-\-help\fP" 4
 Display option summary and exit.
-.IP "\fB\-\-invariant\fR" 4
+.IP "\fB\-\-invariant\fP" 4
 Use constants for normally randomly generated or time based data such as
 volume ID and creation time.
-Multiple runs of \fBmkfs.fat\fR on the same device create identical results
+Multiple runs of \fBmkfs.fat\fP on the same device create identical results
 with this option.
-Its main purpose is testing \fBmkfs.fat\fR.
+Its main purpose is testing \fBmkfs.fat\fP.
 .\" ----------------------------------------------------------------------------
 .SH BUGS
-\fBmkfs.fat\fR can not create boot-able filesystems.
+\fBmkfs.fat\fP can not create boot-able filesystems.
 This isn't as easy as you might think at first glance for various reasons and
 has been discussed a lot already.
-\fBmkfs.fat\fR simply will not support it ;)
+\fBmkfs.fat\fP simply will not support it ;)
 .\" ----------------------------------------------------------------------------
 .SH SEE ALSO
 .BR fatlabel (8),
 .BR fsck.fat (8)
 .\" ----------------------------------------------------------------------------
 .SH HOMEPAGE
-The home for the \fBdosfstools\fR project is its
+The home for the \fBdosfstools\fP project is its
 .UR https://github.com/dosfstools/dosfstools
 GitHub project page
 .UE .
 .\" ----------------------------------------------------------------------------
 .SH AUTHORS
-\fBdosfstools\fR were written by
+\fBdosfstools\fP were written by
 .MT werner.almesberger@\:lrc.di.epfl.ch
 Werner Almesberger
 .ME ,


### PR DESCRIPTION
Fix formatting of hyphens, en and em dashes, emphases, bullets and fix switching to previous font style.

In troff manpage language ascii minus is written as `\-`, mathematical minus as `\(mi`, hyphen as `-`, en-dash as `\(en`, em-dash as `\(em` and bullet as `\(bu`. Previous font style is selected by `\fP`.