### PR TITLE
Fixed off-by-one in local_string_to_dos_string.

### DIFF
--- a/src/charconv.c
+++ b/src/charconv.c
@@ -87,6 +87,6 @@ int local_string_to_dos_string(char *out, char *in, unsigned int len)
                 in, used_codepage);
         return 0;
     }
-    out[len-bytes_out] = 0;
+    out[len-1-bytes_out] = 0;
     return 1;
 }

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -67,12 +67,12 @@ int dos_char_to_printable(char **p, unsigned char c)
     return iconv(dos_to_local, &pin, &bytes_in, p, &bytes_out) != -1;
 }
 
-int local_string_to_dos_string(char *out, char *in, unsigned int len)
+int local_string_to_dos_string(char *out, char *in, unsigned int out_size)
 {
     char *pin = in;
     char *pout = out;
     size_t bytes_in = strlen(in);
-    size_t bytes_out = len-1;
+    size_t bytes_out = out_size-1;
     size_t ret;
     if (!init_conversion(-1))
         return 0;
@@ -87,6 +87,6 @@ int local_string_to_dos_string(char *out, char *in, unsigned int len)
                 in, used_codepage);
         return 0;
     }
-    out[len-1-bytes_out] = 0;
+    out[out_size-1-bytes_out] = 0;
     return 1;
 }

--- a/src/charconv.h
+++ b/src/charconv.h
@@ -5,6 +5,6 @@
 
 int set_dos_codepage(int codepage);
 int dos_char_to_printable(char **p, unsigned char c);
-int local_string_to_dos_string(char *out, char *in, unsigned int len);
+int local_string_to_dos_string(char *out, char *in, unsigned int out_size);
 
 #endif


### PR DESCRIPTION
The function local_string_to_dos_string is vulnerable to an off-by-one
buffer overflow. In fact, it is triggered in default usage and becomes
visible when compiled with ASAN:

$ CFLAGS="-fsanitize=address" ./configure
$ dd if=/dev/zero of=example.iso bs=1024 seek=64 count=1
$ ./src/mkfs.fat example.iso
mkfs.fat 4.1+git (2017-01-24)

=================================================================
==3857==ERROR: AddressSanitizer: stack-buffer-overflow on address ...

The problem is that the argument "len" to local_string_to_dos_string
stores the length of the output buffer. Yet it can also be used as an
index to store '\0':

If the whole "out" buffer has been written to, bytes_out is 0 and
the assignment in out[len-bytes_out] therefore leads to an off-by-one.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>