### PR TITLE
Use unsigned long long type instead of uint64_t

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -231,8 +231,8 @@ static void dump_boot(DOS_FS * fs, struct boot_sector *b, unsigned lss)
 	   (unsigned long long)fs->fat_start,
 	   (unsigned long long)fs->fat_start / lss);
     printf("%10d FATs, %d bit entries\n", b->fats, fs->fat_bits);
-    printf("%10lld bytes per FAT (= %llu sectors)\n", (long long)fs->fat_size,
-	   (long long)fs->fat_size / lss);
+    printf("%10u bytes per FAT (= %u sectors)\n", fs->fat_size,
+	   fs->fat_size / lss);
     if (!fs->root_cluster) {
 	printf("Root directory starts at byte %llu (sector %llu)\n",
 	       (unsigned long long)fs->root_start,

--- a/src/check.c
+++ b/src/check.c
@@ -545,8 +545,11 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 		 next_cluster(fs, walk))
 		if (walk == curr)
 		    break;
-		else
+		else {
+		    if ((unsigned long long)clusters2 * fs->cluster_size >= UINT32_MAX)
+		        die("Internal error: File size is larger than 2^32-1");
 		    clusters2++;
+		}
 	    restart = file->dir_ent.attr & ATTR_DIR;
 	    if (!owner->offset) {
 		printf("  Truncating second to %llu bytes because first "
@@ -606,6 +609,8 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 			this = curr;
 			break;
 		    }
+		    if ((unsigned long long)clusters * fs->cluster_size >= UINT32_MAX)
+		        die("Internal error: File size is larger than 2^32-1");
 		    clusters++;
 		    prev = this;
 		}
@@ -621,6 +626,8 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 	    }
 	}
 	set_owner(fs, curr, file);
+	if ((unsigned long long)clusters * fs->cluster_size >= UINT32_MAX)
+	    die("Internal error: File size is larger than 2^32-1");
 	clusters++;
 	prev = curr;
     }

--- a/src/check.c
+++ b/src/check.c
@@ -526,12 +526,12 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 	    break;
 	}
 	if (!(file->dir_ent.attr & ATTR_DIR) && le32toh(file->dir_ent.size) <=
-	    (uint64_t)clusters * fs->cluster_size) {
+	    clusters * fs->cluster_size) {
 	    printf
-		("%s\n  File size is %u bytes, cluster chain length is > %llu "
+		("%s\n  File size is %u bytes, cluster chain length is > %u "
 		 "bytes.\n  Truncating file to %u bytes.\n", path_name(file),
 		 le32toh(file->dir_ent.size),
-		 (unsigned long long)clusters * fs->cluster_size,
+		 (unsigned)clusters * fs->cluster_size,
 		 le32toh(file->dir_ent.size));
 	    truncate_file(fs, file, clusters);
 	    break;
@@ -552,14 +552,14 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 		}
 	    restart = file->dir_ent.attr & ATTR_DIR;
 	    if (!owner->offset) {
-		printf("  Truncating second to %llu bytes because first "
+		printf("  Truncating second to %u bytes because first "
 		       "is FAT32 root dir.\n",
-		       (unsigned long long)clusters * fs->cluster_size);
+		       (unsigned)clusters * fs->cluster_size);
 		do_trunc = 2;
 	    } else if (!file->offset) {
-		printf("  Truncating first to %llu bytes because second "
+		printf("  Truncating first to %u bytes because second "
 		       "is FAT32 root dir.\n",
-		       (unsigned long long)clusters2 * fs->cluster_size);
+		       (unsigned)clusters2 * fs->cluster_size);
 		do_trunc = 1;
 	    } else {
 		char *trunc_first_string;
@@ -567,15 +567,15 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 		char *noninteractive_string;
 
 		xasprintf(&trunc_first_string,
-			 "Truncate first to %llu bytes%s",
-			 (unsigned long long)clusters2 * fs->cluster_size,
+			 "Truncate first to %u bytes%s",
+			 (unsigned)clusters2 * fs->cluster_size,
 			 restart ? " and restart" : "");
 		xasprintf(&trunc_second_string,
-			  "Truncate second to %llu bytes",
-			  (unsigned long long)clusters * fs->cluster_size);
+			  "Truncate second to %u bytes",
+			  (unsigned)clusters * fs->cluster_size);
 		xasprintf(&noninteractive_string,
-			  "  Truncating second to %llu bytes.",
-			  (unsigned long long)clusters * fs->cluster_size);
+			  "  Truncating second to %u bytes.",
+			  (unsigned)clusters * fs->cluster_size);
 
 		do_trunc = get_choice(2, noninteractive_string,
 				      2,
@@ -597,9 +597,7 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 			    set_fat(fs, prev, -1);
 			else
 			    MODIFY_START(owner, 0, fs);
-			MODIFY(owner, size,
-			       htole32((uint64_t)clusters *
-				       fs->cluster_size));
+			MODIFY(owner, size, htole32(clusters * fs->cluster_size));
 			if (restart)
 			    return 1;
 			while (this > 0 && this != -1) {
@@ -632,15 +630,15 @@ static int check_file(DOS_FS * fs, DOS_FILE * file)
 	prev = curr;
     }
     if (!(file->dir_ent.attr & ATTR_DIR) && le32toh(file->dir_ent.size) >
-	(uint64_t)clusters * fs->cluster_size) {
+	clusters * fs->cluster_size) {
 	printf
-	    ("%s\n  File size is %u bytes, cluster chain length is %llu bytes."
-	     "\n  Truncating file to %llu bytes.\n", path_name(file),
+	    ("%s\n  File size is %u bytes, cluster chain length is %u bytes."
+	     "\n  Truncating file to %u bytes.\n", path_name(file),
 	     le32toh(file->dir_ent.size),
-	     (unsigned long long)clusters * fs->cluster_size,
-	     (unsigned long long)clusters * fs->cluster_size);
+	     (unsigned)clusters * fs->cluster_size,
+	     (unsigned)clusters * fs->cluster_size);
 	MODIFY(file, size,
-	       htole32((uint64_t)clusters * fs->cluster_size));
+	       htole32(clusters * fs->cluster_size));
     }
     return 0;
 }

--- a/src/fat.c
+++ b/src/fat.c
@@ -366,6 +366,7 @@ uint32_t next_cluster(DOS_FS * fs, uint32_t cluster)
 
 off_t cluster_start(DOS_FS * fs, uint32_t cluster)
 {
+    /* TODO: check overflow */
     return fs->data_start + ((off_t)cluster - 2) * (unsigned long long)fs->cluster_size;
 }
 

--- a/src/fat.c
+++ b/src/fat.c
@@ -366,7 +366,7 @@ uint32_t next_cluster(DOS_FS * fs, uint32_t cluster)
 
 off_t cluster_start(DOS_FS * fs, uint32_t cluster)
 {
-    return fs->data_start + ((off_t)cluster - 2) * (uint64_t)fs->cluster_size;
+    return fs->data_start + ((off_t)cluster - 2) * (unsigned long long)fs->cluster_size;
 }
 
 /**

--- a/src/fsck.fat.h
+++ b/src/fsck.fat.h
@@ -157,7 +157,7 @@ typedef struct {
 typedef struct {
     int nfats;
     off_t fat_start;
-    off_t fat_size;		/* unit is bytes */
+    unsigned int fat_size;	/* unit is bytes */
     unsigned int fat_bits;	/* size of a FAT entry */
     unsigned int eff_fat_bits;	/* # of used bits in a FAT entry */
     uint32_t root_cluster;	/* 0 for old-style root dir */

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -407,7 +407,7 @@ static void check_blocks(void)
     try = TEST_BUFFER_BLOCKS;
     while (currently_testing < blocks) {
 	if (currently_testing + try > blocks)
-	    try = blocks - currently_testing;
+	    try = blocks - currently_testing; /* TODO: check overflow */
 	got = do_check(blkbuf, try, currently_testing);
 	currently_testing += got;
 	if (got == try) {
@@ -1876,7 +1876,7 @@ int main(int argc, char **argv)
 		die("unable to create %s", device_name);
 	}
 	/* expand to desired size */
-	if (ftruncate(dev, part_sector * sector_size + blocks * BLOCK_SIZE))
+	if (ftruncate(dev, part_sector * sector_size + blocks * BLOCK_SIZE)) /* TODO: check overflow */
 	    die("unable to resize %s", device_name);
     }
 

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -236,7 +236,7 @@ static int verbose = 0;		/* Default to verbose mode off */
 static long volume_id;		/* Volume ID number */
 static time_t create_time = -1;	/* Creation time */
 static char *volume_name = initial_volume_name;	/* Volume name */
-static uint64_t blocks;	/* Number of blocks in filesystem */
+static unsigned long long blocks;	/* Number of blocks in filesystem */
 static unsigned sector_size = 512;	/* Size of a logical sector */
 static int sector_size_set = 0;	/* User selected sector size */
 static int backup_boot = 0;	/* Sector# of backup boot sector */
@@ -781,7 +781,7 @@ static void setup_tables(void)
 	    UINT32_MAX) {
 	printf("Warning: target too large, space at end will be left unused\n");
 	num_sectors = UINT32_MAX;
-	blocks = (uint64_t)UINT32_MAX * sector_size / BLOCK_SIZE;
+	blocks = (unsigned long long)UINT32_MAX * sector_size / BLOCK_SIZE;
     } else {
 	num_sectors =
 	    (long long)(blocks * BLOCK_SIZE / sector_size) + orphaned_sectors;
@@ -1473,7 +1473,7 @@ int main(int argc, char **argv)
     struct device_info devinfo;
     int i = 0, pos, ch;
     int create = 0;
-    uint64_t cblocks = 0;
+    unsigned long long cblocks = 0;
     int blocks_specified = 0;
     struct timeval create_timeval;
     long long conversion;
@@ -1916,7 +1916,7 @@ int main(int argc, char **argv)
 	if (blocks != cblocks) {
 	    fprintf(stderr, "Warning: block count mismatch: ");
 	    fprintf(stderr, "found %llu but assuming %llu.\n",
-		    (unsigned long long)cblocks, (unsigned long long)blocks);
+		    cblocks, blocks);
 	}
     } else {
 	blocks = cblocks;


### PR DESCRIPTION
In dosfstools codebase is primary used `unsigned long long` type for 64bit integers and on few places `uint64_t`. So replace `uint64_t` by `unsigned long long` type and fix some casting problems around.