### PR TITLE
Use static inline function instead of statement expression

### DIFF
--- a/src/lfn.c
+++ b/src/lfn.c
@@ -150,9 +150,9 @@ static void copy_lfn_part(unsigned char *dst, LFN_ENT * lfn)
 /* Convert name part in 'lfn' from unicode to ASCII */
 static inline char *cnv_this_part(LFN_ENT *lfn)
 {
-	unsigned char part_uni[CHARS_PER_LFN*2];
-	copy_lfn_part( part_uni, lfn );
-	return cnv_unicode( part_uni, CHARS_PER_LFN, 0 );
+	unsigned char part_uni[CHARS_PER_LFN * 2];
+	copy_lfn_part(part_uni, lfn);
+	return cnv_unicode(part_uni, CHARS_PER_LFN, 0);
 }
 
 static void clear_lfn_slots(int start, int end)

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -74,14 +74,6 @@ static unsigned char fat_uni2esc[64] = {
 /* for maxlen param */
 #define UNTIL_0		INT_MAX
 
-/* Convert name part in 'lfn' from unicode to ASCII */
-#define CNV_THIS_PART(lfn)				\
-    ({							\
-	unsigned char __part_uni[CHARS_PER_LFN*2];		\
-	copy_lfn_part( __part_uni, lfn );		\
-	cnv_unicode( __part_uni, CHARS_PER_LFN, 0 );	\
-    })
-
 /* Convert name parts collected so far (from previous slots) from unicode to
  * ASCII */
 #define CNV_PARTS_SO_FAR()					\
@@ -155,6 +147,14 @@ static void copy_lfn_part(unsigned char *dst, LFN_ENT * lfn)
     memcpy(dst + 22, lfn->name11_12, 4);
 }
 
+/* Convert name part in 'lfn' from unicode to ASCII */
+static inline char *cnv_this_part(LFN_ENT *lfn)
+{
+	unsigned char __part_uni[CHARS_PER_LFN*2];
+	copy_lfn_part( __part_uni, lfn );
+	return cnv_unicode( __part_uni, CHARS_PER_LFN, 0 );
+}
+
 static void clear_lfn_slots(int start, int end)
 {
     int i;
@@ -222,7 +222,7 @@ void lfn_add_slot(DIR_ENT * de, off_t dir_offset)
 	     * display the name) */
 	    printf("A new long file name starts within an old one.\n");
 	    if (slot == lfn_slot && lfn->alias_checksum == lfn_checksum) {
-		char *part1 = CNV_THIS_PART(lfn);
+		char *part1 = cnv_this_part(lfn);
 		char *part2 = CNV_PARTS_SO_FAR();
 		printf("  It could be that the LFN start bit is wrong here\n"
 		       "  if \"%s\" seems to match \"%s\".\n", part1, part2);
@@ -258,7 +258,7 @@ void lfn_add_slot(DIR_ENT * de, off_t dir_offset)
 	/* Causes: 1) start bit got lost, 2) Previous slot with start bit got
 	 *         lost */
 	/* Fixes: 1) delete LFN, 2) set start bit */
-	char *part = CNV_THIS_PART(lfn);
+	char *part = cnv_this_part(lfn);
 	printf("Long filename fragment \"%s\" found outside a LFN "
 	       "sequence.\n  (Maybe the start bit is missing on the "
 	       "last fragment)\n", part);
@@ -299,7 +299,7 @@ void lfn_add_slot(DIR_ENT * de, off_t dir_offset)
 	printf("Unexpected long filename sequence number "
 	       "(%d vs. expected %d).\n", slot, lfn_slot);
 	if (lfn->alias_checksum == lfn_checksum && lfn_slot > 0) {
-	    char *part1 = CNV_THIS_PART(lfn);
+	    char *part1 = cnv_this_part(lfn);
 	    char *part2 = CNV_PARTS_SO_FAR();
 	    printf("  It could be that just the number is wrong\n"
 		   "  if \"%s\" seems to match \"%s\".\n", part1, part2);

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -150,9 +150,9 @@ static void copy_lfn_part(unsigned char *dst, LFN_ENT * lfn)
 /* Convert name part in 'lfn' from unicode to ASCII */
 static inline char *cnv_this_part(LFN_ENT *lfn)
 {
-	unsigned char __part_uni[CHARS_PER_LFN*2];
-	copy_lfn_part( __part_uni, lfn );
-	return cnv_unicode( __part_uni, CHARS_PER_LFN, 0 );
+	unsigned char part_uni[CHARS_PER_LFN*2];
+	copy_lfn_part( part_uni, lfn );
+	return cnv_unicode( part_uni, CHARS_PER_LFN, 0 );
 }
 
 static void clear_lfn_slots(int start, int end)


### PR DESCRIPTION
Not sure if this needs to be inlined, but I made it `inline` to match the existing macro.