### PR TITLE
configure: Fix iconv check for cross compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,8 @@ if test "x$with_udev" != "xno"; then
 		  [true])
 fi
 
-AC_SEARCH_LIBS(iconv_open, iconv)
+AC_CHECK_LIB(iconv, iconv_open)
+AC_CHECK_LIB(iconv, libiconv_open)
 
 # xxd (distributed with vim) is used in the testsuite
 AC_CHECK_PROG([XXD_FOUND], [xxd], [yes])


### PR DESCRIPTION
AC_CHECK_LIB is more friendly towards cross-compilation.

Added check for libiconv_open as that can be used when the libc lacks iconv.