### PR TITLE
More fixes for charconv code

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -783,7 +783,7 @@ void remove_label(DOS_FS *fs)
 
 const char *pretty_label(const char *label)
 {
-    static char buffer[11*4+1];
+    static char buffer[256];
     char *p;
     int i;
     int last;

--- a/src/boot.c
+++ b/src/boot.c
@@ -794,8 +794,8 @@ const char *pretty_label(const char *label)
     }
 
     p = buffer;
-    for (i = 0; i <= last && label[i]; ++i) {
-        if (!dos_char_to_printable(&p, label[i]))
+    for (i = 0; i <= last && label[i] && p < buffer + sizeof(buffer) - 1; ++i) {
+        if (!dos_char_to_printable(&p, label[i], buffer + sizeof(buffer) - 1 - p))
             *p++ = '_';
     }
     *p = 0;

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -188,7 +188,7 @@ int dos_char_to_printable(char **p, unsigned char c, unsigned int out_size)
 	return 0;
     if (internal_cp850)
         return cp850_char_to_printable(p, c, out_size);
-    return iconv(dos_to_local, &pin, &bytes_in, p, &bytes_out) != -1;
+    return iconv(dos_to_local, &pin, &bytes_in, p, &bytes_out) != (size_t)-1;
 }
 
 int local_string_to_dos_string(char *out, char *in, unsigned int out_size)

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -33,6 +33,26 @@ static const wchar_t cp850_table[128] = {
     0x00b0, 0x00a8, 0x00b7, 0x00b9, 0x00b3, 0x00b2, 0x25a0, 0x00a0,
 };
 
+/* CP850 translit table to 7bit ASCII for 0x80-0xFF range */
+static const char *const cp850_translit_table[128] = {
+    "C",   "u",   "e",  "a",     "a",     "a", "a",   "c",
+    "e",   "e",   "e",  "i",     "i",     "i", "A",   "A",
+    "E",   "ae",  "AE", "o",     "o",     "o", "u",   "u",
+    "y",   "O",   "U",  "o",     "GBP",   "O", "x",   "f",
+    "a",   "i",   "o",  "u",     "n",     "N", "a",   "o",
+    "?",   "(R)", "!",  " 1/2 ", " 1/4 ", "!", "<<",  ">>",
+    "?",   "?",   "?",  "|",     "+",     "A", "A",   "A",
+    "(C)", "?",   "?",  "?",     "?",     "c", "JPY", "+",
+    "+",   "+",   "+",  "+",     "-",     "+", "a",   "A",
+    "?",   "?",   "?",  "?",     "?",     "?", "?",   "?",
+    "d",   "D",   "E",  "E",     "E",     "i", "I",   "I",
+    "I",   "+",   "+",  "?",     "?",     "|", "I",   "?",
+    "O",   "ss",  "O",  "O",     "o",     "O", "u",   "th",
+    "TH",  "U",   "U",  "U",     "y",     "Y", "?",   "'",
+    "-",   "+-",  "?",  " 3/4 ", "?",     "?", "/",   ",",
+    "?",   "?",   ".",  "1",     "3",     "2", "?",   " ",
+};
+
 static int wchar_string_to_cp850_string(char *out, const wchar_t *in, unsigned int out_size)
 {
     unsigned i, j;
@@ -62,7 +82,14 @@ static int cp850_char_to_printable(char **p, unsigned char c)
     int ret = wctomb(*p, wc);
     if (ret != -1)
         *p += ret;
-    return ret != -1;
+    else if (!(c & 0x80))
+        *(*p++) = c;
+    else {
+        ret = strlen(cp850_translit_table[c & 0x7F]);
+        memcpy(*p, cp850_translit_table[c & 0x7F], ret);
+        *p += ret;
+    }
+    return 1;
 }
 
 static int local_string_to_cp850_string(char *out, const char *in, unsigned int out_size)

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -33,7 +33,7 @@ static const wchar_t cp850_table[128] = {
     0x00b0, 0x00a8, 0x00b7, 0x00b9, 0x00b3, 0x00b2, 0x25a0, 0x00a0,
 };
 
-static int wchar_string_to_cp850_string(char *out, wchar_t *in, unsigned int out_size)
+static int wchar_string_to_cp850_string(char *out, const wchar_t *in, unsigned int out_size)
 {
     unsigned i, j;
     for (i = 0; i < out_size-1 && in[i]; ++i) {
@@ -65,7 +65,7 @@ static int cp850_char_to_printable(char **p, unsigned char c)
     return ret != -1;
 }
 
-static int local_string_to_cp850_string(char *out, char *in, unsigned int out_size)
+static int local_string_to_cp850_string(char *out, const char *in, unsigned int out_size)
 {
     int ret;
     wchar_t *wcs;

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -214,7 +214,15 @@ int local_string_to_dos_string(char *out, char *in, unsigned int out_size)
         else
             fprintf(stderr, "Cannot convert input sequence '\\x%.02hhX' from codeset '%s' to 'CP%d': %s\n",
                     *pin, nl_langinfo(CODESET), used_codepage, strerror(errno));
+        iconv(local_to_dos, NULL, NULL, &pout, &bytes_out);
         return 0;
+    } else {
+        ret = iconv(local_to_dos, NULL, NULL, &pout, &bytes_out);
+        if (ret == (size_t)-1) {
+            fprintf(stderr, "Cannot convert input string '%s' to 'CP%d': String is too long\n",
+                    in, used_codepage);
+            return 0;
+        }
     }
     out[out_size-1-bytes_out] = 0;
     return 1;

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -200,9 +200,9 @@ int dos_char_to_printable(char **p, unsigned char c)
     return cp850_char_to_printable(p, c);
 }
 
-int local_string_to_dos_string(char *out, char *in, unsigned int len)
+int local_string_to_dos_string(char *out, char *in, unsigned int out_size)
 {
-    return local_string_to_cp850_string(out, in, len);
+    return local_string_to_cp850_string(out, in, out_size);
 }
 
 #endif

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -143,7 +143,7 @@ static int internal_cp850;
 /*
  * Initialize conversion from codepage.
  * codepage = -1 means default codepage.
- * Returns 0 on success, non-zero on failure
+ * Returns non-zero on success, 0 on failure
  */
 static int init_conversion(int codepage)
 {

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -68,7 +68,7 @@ static int wchar_string_to_cp850_string(char *out, const wchar_t *in, unsigned i
             }
         }
         if (j == 0x80) {
-            fprintf(stderr, "Cannot convert input character '%lc' to 'CP850': %s\n", (wint_t)in[i], strerror(EILSEQ));
+            fprintf(stderr, "Cannot convert input character 0x%04x to 'CP850': %s\n", (unsigned int)in[i], strerror(EILSEQ));
             return 0;
         }
     }

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -181,7 +181,7 @@ int set_dos_codepage(int codepage)
 int dos_char_to_printable(char **p, unsigned char c, unsigned int out_size)
 {
     char in[1] = { c };
-    char *pin = in;
+    ICONV_CONST char *pin = in;
     size_t bytes_in = 1;
     size_t bytes_out = out_size;
     if (!init_conversion(-1))
@@ -193,7 +193,7 @@ int dos_char_to_printable(char **p, unsigned char c, unsigned int out_size)
 
 int local_string_to_dos_string(char *out, char *in, unsigned int out_size)
 {
-    char *pin = in;
+    ICONV_CONST char *pin = in;
     char *pout = out;
     size_t bytes_in = strlen(in);
     size_t bytes_out = out_size-1;

--- a/src/charconv.c
+++ b/src/charconv.c
@@ -95,6 +95,10 @@ static int iconv_init_codepage(int codepage, iconv_t *to_local, iconv_t *from_lo
     char codepage_name[32];
     snprintf(codepage_name, sizeof(codepage_name), "CP%d//TRANSLIT", codepage);
     *to_local = iconv_open(nl_langinfo(CODESET), codepage_name);
+    if (*to_local == (iconv_t) - 1) {
+        snprintf(codepage_name, sizeof(codepage_name), "CP%d", codepage);
+        *to_local = iconv_open(nl_langinfo(CODESET), codepage_name);
+    }
     if (*to_local == (iconv_t) - 1)
         fprintf(stderr, "Cannot initialize conversion from codepage %d to %s: %s\n", codepage, nl_langinfo(CODESET), strerror(errno));
     snprintf(codepage_name, sizeof(codepage_name), "CP%d", codepage);

--- a/src/charconv.h
+++ b/src/charconv.h
@@ -4,7 +4,7 @@
 #define DEFAULT_DOS_CODEPAGE 850
 
 int set_dos_codepage(int codepage);
-int dos_char_to_printable(char **p, unsigned char c);
+int dos_char_to_printable(char **p, unsigned char c, unsigned int out_size);
 int local_string_to_dos_string(char *out, char *in, unsigned int out_size);
 
 #endif

--- a/src/file.c
+++ b/src/file.c
@@ -37,13 +37,13 @@
 
 FDSC *fp_root = NULL;
 
-static void put_char(char **p, unsigned char c)
+static void put_char(char **p, unsigned char c, unsigned int out_size)
 {
-    if (dos_char_to_printable(p, c))
+    if (dos_char_to_printable(p, c, out_size))
 	return;
-    if (c >= ' ' && c < 0x7f)
+    if (out_size >= 1 && c >= ' ' && c < 0x7f)
 	*(*p)++ = c;
-    else {
+    else if (out_size >= 4) {
 	*(*p)++ = '\\';
 	*(*p)++ = '0' + (c >> 6);
 	*(*p)++ = '0' + ((c >> 3) & 7);
@@ -68,7 +68,7 @@ char *file_name(unsigned char *fixed)
     p = path;
     i = j = 0;
     if (fixed[0] == 0x05) {
-        put_char(&p, 0xe5);
+        put_char(&p, 0xe5, path + sizeof(path) - 1 - p);
         ++i;
         ++j;
     }
@@ -76,7 +76,7 @@ char *file_name(unsigned char *fixed)
 	if (fixed[i] != ' ') {
 	    while (j++ < i)
 		*p++ = ' ';
-	    put_char(&p, fixed[i]);
+	    put_char(&p, fixed[i], path + sizeof(path) - 1 - p);
 	}
     if (strncmp((const char *)(fixed + 8), "   ", 3)) {
 	*p++ = '.';
@@ -84,7 +84,7 @@ char *file_name(unsigned char *fixed)
 	    if (fixed[i + 8] != ' ') {
 		while (j++ < i)
 		    *p++ = ' ';
-		put_char(&p, fixed[i + 8]);
+		put_char(&p, fixed[i + 8], path + sizeof(path) - 1 - p);
 	    }
     }
     *p = 0;

--- a/src/file.c
+++ b/src/file.c
@@ -61,7 +61,7 @@ static void put_char(char **p, unsigned char c, unsigned int out_size)
  */
 char *file_name(unsigned char *fixed)
 {
-    static char path[MSDOS_NAME * 4 + 2];
+    static char path[256];
     char *p;
     int i, j;
 

--- a/src/file.c
+++ b/src/file.c
@@ -41,7 +41,7 @@ static void put_char(char **p, unsigned char c)
 {
     if (dos_char_to_printable(p, c))
 	return;
-    if ((c >= ' ' && c < 0x7f) || c >= 0xa0)
+    if (c >= ' ' && c < 0x7f)
 	*(*p)++ = c;
     else {
 	*(*p)++ = '\\';


### PR DESCRIPTION
Fix fallback translit code and add internal CP850 translit table. Fix buffer overflows by specifying output buffer size. Fix usage of iconv() function and use ICONV_CONST autoconf macro.