### PR TITLE
mkfs.fat: Relax -D option (BIOS drive number)

### DIFF
--- a/manpages/mkfs.fat.8.in
+++ b/manpages/mkfs.fat.8.in
@@ -94,8 +94,10 @@ The resulting file can be copied later to a floppy disk or other device, or
 mounted through a loop device.
 .IP "\fB\-D\fP \fIDRIVE-NUMBER\fP" 4
 Specify the BIOS drive number to be stored in the FAT boot sector.
-This value is usually 0x80 for hard disks and 0x00 for floppy devices or
-partitions to be used for floppy emulation.
+For hard disks and removable medias it is usually 0x80\(en0xFF (0x80 is first
+hard disk C:, 0x81 is second hard disk D:, ...), for floppy devices or
+partitions to be used for floppy emulation it is 0x00\(en0x7F (0x00 is first
+floppy A:, 0x01 is second floppy B:).
 .IP "\fB\-f\fP \fINUMBER-OF-FATS\fP" 4
 Specify the number of file allocation tables in the filesystem.
 The default is 2.

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1541,8 +1541,8 @@ int main(int argc, char **argv)
 	case 'D':		/* D : Choose Drive Number */
 	    errno = 0;
 	    conversion = strtol(optarg, &tmp, 0);
-	    if (!*optarg || isspace(*optarg) || *tmp || errno || (conversion != 0 && conversion != 0x80)) {
-		printf ("Drive number must be 0 or 0x80: %s\n", optarg);
+	    if (!*optarg || isspace(*optarg) || *tmp || errno || conversion < 0x00 || conversion > 0xFF) {
+		printf ("Bad drive number: %s\n", optarg);
 		usage(argv[0], 1);
 	    }
 	    drive_number_option = conversion;


### PR DESCRIPTION
Allow to specify also second hard disk (0x81) or second floppy device
(0x01) as -D option = BIOS drive number.