### PR TITLE
fsck.fat: preserve info sector reserved fields

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -334,9 +334,8 @@ static void check_backup_boot(DOS_FS * fs, struct boot_sector *b, unsigned int l
     }
 }
 
-static void init_fsinfo(struct info_sector *i)
+static void init_fsinfo_except_reserved(struct info_sector *i)
 {
-    memset(i, 0, sizeof (struct info_sector));
     i->magic = htole32(0x41615252);
     i->signature = htole32(0x61417272);
     i->free_clusters = htole32(-1);
@@ -361,7 +360,8 @@ static void read_fsinfo(DOS_FS * fs, struct boot_sector *b, unsigned int lss)
 		if (s != le16toh(b->backup_boot))
 		    break;
 	    if (s > 0 && s < le16toh(b->reserved)) {
-		init_fsinfo(&i);
+		memset(&i, 0, sizeof (struct info_sector));
+		init_fsinfo_except_reserved(&i);
 		fs_write((off_t)s * lss, sizeof(i), &i);
 		b->info_sector = htole16(s);
 		fs_write(offsetof(struct boot_sector, info_sector),
@@ -401,7 +401,7 @@ static void read_fsinfo(DOS_FS * fs, struct boot_sector *b, unsigned int lss)
 		       2,
 		       1, "Correct",
 		       2, "Don't correct (FSINFO invalid then)") == 1) {
-	    init_fsinfo(&i);
+	    init_fsinfo_except_reserved(&i);
 	    fs_write(fs->fsinfo_start, sizeof(i), &i);
 	} else
 	    fs->fsinfo_start = 0;


### PR DESCRIPTION
This allows the FSIBOOT stage of lDOS boot32.asm to remain
in the FSINFO sector even when the info entries are reset.

I reviewed several sources to determine whether we are in the right to
assume that the reserved 480 bytes used by FSIBOOT should be preserved
by drivers updating the FSINFO entry fields.

Quoting the document "Microsoft Extensible Firmware Initiative - FAT32
File System Specification - FAT: General Overview of On-Disk Format -
Version 1.03, December 6, 2000" on these bytes:

> [Name] FSI_Reserved1
>
> [Offset (byte)] 4
>
> [Size (bytes)] 480
>
> [Description] This field is currently reserved for future expansion.
> FAT32 format code should always initialize all bytes of this field
> to 0. Bytes in this field must currently never be used.

This specifically states that "FAT32 format code" should zero-initialise
this space. It does not specify that a driver should or should not reset
this space.

The FreeDOS kernel uses a struct [1] that does not include the space
used by FSIBOOT. Its driver's implementation [2] does preserve the
FSIBOOT area. I have verified this in dosemu2; if the FreeDOS kernel
updates the FSINFO sector it preserves this area.

The Linux kernel uses a struct with a "reserved1" member [3] which is
commented as being "Nothing as far as I can tell". If I am reading the
source correctly, its driver [4] also preserves this area when updating
the FSINFO entries.

Testing on MS-DOS version 7.10 (as bundled with MS Windows 98 SE) I
determined that it also preserves the area when updating the FSINFO entries.

The free software RxDOS/lDOS boot loader for FAT32 that I wrote uses
this reserved area to store its FSIBOOT stage, essentially an extension
to the primary boot sector loader. To avoid clashing with Microsoft
loaders which may use some of the reserved sectors, the large reserved
area in the FSINFO sector was selected to hold this stage (if sector
size is <= 512 bytes). If valid, the area starts with a signature [5]
the first four bytes of which form the letters "FSIB"; the subsequent
four bytes specify a protocol version. For example, the current
(non-experimental) version is "FSIBOOT3" [6].

If there is no FSINFO sector or the FSIBOOT signature does not match the
one expected, then the 'I' error code letter ("i"nvalid FS"I"BOOT) is
displayed and the loading is aborted [7]. Prior to this patch, if the
FSINFO entries were invalid (any of the three FSINFO signatures don't
match) and then fsck.fat was used and instructed to correct this, it
would reset the space used by FSIBOOT, rendering the image unbootable
if the lDOS boot32 loader had been installed into the image.

I previously posted a similar patch for mtools to the info-mtools
mailing list [8]. I was approached to check whether dosfstools behaved
as expected. I determined that this patch is needed to fix the corner
case of invalid FSINFO entries with FSIBOOT installed into the sector.
I also patched the lDOS instsect application [9] so it insures that the
FSINFO entries are valid while installing FSIBOOT. With either that
patch to instsect or this patch to dosfstools, FSIBOOT will always be
preserved when running fsck.fat on a file system.

[1]:
https://github.com/FDOS/kernel/blob/6e42bb6d7c6dd304f738cf0d7a2db719598f1b9e/hdr/device.h#L325
[2]:
https://github.com/FDOS/kernel/blob/6e42bb6d7c6dd304f738cf0d7a2db719598f1b9e/kernel/fattab.c#L116
[3]:
https://github.com/torvalds/linux/blob/7cf726a59435301046250c42131554d9ccc566b8/include/uapi/linux/msdos_fs.h#L163
[4]:
https://github.com/torvalds/linux/blob/7cf726a59435301046250c42131554d9ccc566b8/fs/fat/misc.c#L60
[5]: https://hg.ulukai.org/ecm/ldosboot/file/aa15fd7bc58e/boot32.asm#l1164
[6]: https://hg.ulukai.org/ecm/ldosboot/file/aa15fd7bc58e/boot32.asm#l27
[7]: https://hg.ulukai.org/ecm/ldosboot/file/aa15fd7bc58e/boot32.asm#l775
[8]: https://lists.gnu.org/archive/html/info-mtools/2020-10/msg00000.html
[9]: https://hg.ulukai.org/ecm/instsect/rev/eee5dfaa52f6