### PR TITLE
mkfs.fat: lower sectors per cluster for drive with large sector

### DIFF
--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -587,6 +587,10 @@ static void establish_params(struct device_info *info)
 	cluster_size =
 	    sz_mb > 32 * 1024 ? 64 : sz_mb > 16 * 1024 ? 32 : sz_mb >
 	    8 * 1024 ? 16 : sz_mb > 260 ? 8 : 1;
+	if (info->sector_size % HARD_SECTOR_SIZE == 0 &&
+	    cluster_size % (info->sector_size / HARD_SECTOR_SIZE) == 0) {
+	    cluster_size = cluster_size / (info->sector_size / HARD_SECTOR_SIZE);
+	}
     }
 
     if (info->geom_heads > 0) {


### PR DESCRIPTION
In the case of FAT32, eliminate the need (when it's safe) of specifying a smaller -s when the drive is e.g. an AF 4Kn drive. Currently the following error may occur:

WARNING: Not enough clusters for a 32 bit FAT!
mkfs.fat: Attempting to create a too large filesystem

Alternative approach to #112 / fix #111.