### PR TITLE
fix: patch for osx build

### DIFF
--- a/src/blkdev/blkdev.c
+++ b/src/blkdev/blkdev.c
@@ -7,7 +7,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
-#include <sys/sysmacros.h>
+#ifdef HAVE_SYS_SYSMACROS_H
+# include <sys/sysmacros.h>
+#endif
 #include <unistd.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/device_info.c
+++ b/src/device_info.c
@@ -24,7 +24,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
-#include <sys/sysmacros.h>
+
+#ifdef HAVE_SYS_SYSMACROS_H
+# include <sys/sysmacros.h>
+#endif
 
 #ifdef HAVE_LINUX_LOOP_H
 #include <linux/loop.h>


### PR DESCRIPTION
```
device_info.c:27:10: fatal error: 'sys/sysmacros.h' file not found
#include <sys/sysmacros.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
```

relates to https://github.com/Homebrew/homebrew-core/pull/70104