### PR TITLE
Fix building on macos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,7 @@ AC_CHECK_HEADERS([\
 		  sys/ioccom.h \
 		  sys/mkdev.h \
 		  sys/queue.h \
+		  sys/sysmacros.h \
 		  ])
 
 AC_CHECK_HEADERS([endian.h sys/endian.h libkern/OSByteOrder.h])

--- a/src/blkdev/blkdev.c
+++ b/src/blkdev/blkdev.c
@@ -7,11 +7,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
-#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <limits.h>
+
+#ifdef HAVE_SYS_SYSMACROS_H
+#include <sys/sysmacros.h>
+#endif
 
 #ifdef HAVE_LINUX_HDREG_H
 #include <linux/hdreg.h>

--- a/src/device_info.c
+++ b/src/device_info.c
@@ -24,7 +24,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+
+#ifdef HAVE_SYS_SYSMACROS_H
 #include <sys/sysmacros.h>
+#endif
 
 #ifdef HAVE_LINUX_LOOP_H
 #include <linux/loop.h>


### PR DESCRIPTION
This is the same as #158 but based on master and includes the required change of configure.ac (https://github.com/dosfstools/dosfstools/pull/158#issuecomment-770943078) to avoid build failure on Debian 10

Fixes: #158
Fixes: #159