### PR TITLE
fatlabel: fix range check for signed characters

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -360,7 +360,7 @@ int validate_volume_label(char *doslabel)
        code page) are not allowed.
      */
     for (i = 0; i < 11; i++) {
-        if (doslabel[i] < 0x20)
+        if ((unsigned) doslabel[i] < 0x20)
             ret |= 0x02;
         if (doslabel[i] == 0x22 ||
             (doslabel[i] >= 0x2A && doslabel[i] <= 0x2C) ||


### PR DESCRIPTION
char may be either signed or unsigned and if it is signed the "< 0x20"
comparison will reject any values >= 0x80 even though these are valid
characters in a label.

Cast to an unsigned type to ensure the full range of valid characters
are accepted.