### PR TITLE
mkfs.fat: Fix bad sector marking check

### DIFF
--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -32,10 +32,10 @@
 
    As far as possible the aim here is to make the "mkfs.fat" command
    look almost identical to the other Linux filesystem make utilties,
-   eg bad blocks are still specified as blocks, not sectors, but when
-   it comes down to it, DOS is tied to the idea of a sector (512 bytes
-   as a rule), and not the block.  For example the boot block does not
-   occupy a full cluster.
+   e.g. bad blocks are still specified as blocks, not sectors, but
+   when it comes down to it, DOS is tied to the idea of a sector
+   (commonly 512 bytes), and not the block.  For example the boot
+   sector does not normally occupy a full cluster.
 
    Fixes/additions May 1998 by Roman Hodek
    <Roman.Hodek@informatik.uni-erlangen.de>:
@@ -78,19 +78,8 @@
 
 #define TEST_BUFFER_BLOCKS 16
 #define BLOCK_SIZE         1024
-#define UNIT_SIZE          512
-#define UNITS_PER_BLOCK ( BLOCK_SIZE / UNIT_SIZE )
 
 #define NO_NAME "NO NAME    "
-
-/* Macro definitions */
-
-/* Compute ceil(a/b) */
-
-static inline int cdiv(int a, int b)
-{
-    return (a + b - 1) / b;
-}
 
 /* FAT values */
 #define FAT_EOF      (atari_format ? 0x0fffffff : 0x0ffffff8)
@@ -248,7 +237,6 @@ static off_t part_sector = 0; /* partition offset in sector */
 static int ignore_safety_checks = 0;	/* Ignore safety checks */
 static off_t currently_testing = 0;	/* Block currently being tested (if autodetect bad blocks) */
 static struct msdos_boot_sector bs;	/* Boot sector data */
-static unsigned long long start_data_unit;	/* Sector number for the start of the data area in 512 byte sectors*/
 static unsigned long start_data_sector;	/* Sector number for the start of the data area */
 static unsigned long long start_data_block;	/* Block number for the start of the data area */
 static unsigned char *fat;	/* File allocation table */
@@ -274,6 +262,13 @@ static int invariant = 0;		/* Whether to set normally randomized or
 					   current time based values to
 					   constants */
 static int fill_mbr_partition = -1;	/* Whether to fill MBR partition table or not */
+
+/* Compute ceil(a/b) */
+
+static inline unsigned long long cdiv(unsigned long long a, unsigned long long b)
+{
+    return (a + b - 1) / b;
+}
 
 /* Function prototype definitions */
 
@@ -337,16 +332,25 @@ static void mark_FAT_cluster(long cluster, unsigned int value)
 
 static void mark_block_bad(unsigned long long blockno)
 {
-    int i, cluster, unit;
+    long first_cluster = (blockno - start_data_block) * BLOCK_SIZE / sector_size /
+        bs.cluster_size + 2;
+    int num_clusters = cdiv(BLOCK_SIZE, sector_size * bs.cluster_size);
+    int i;
+    long cluster;
 
-    for (i = 0; i < UNITS_PER_BLOCK; i++) {
-        unit = blockno * UNITS_PER_BLOCK + i;
-        cluster = (unit - start_data_unit) / (int)(bs.cluster_size) /
-            (sector_size / UNIT_SIZE) + 2;
+    if (blockno < start_data_block)
+        die("Bad blocks before data area: cannot make fs");
+    if (blockno >= blocks)
+        die("Internal error: out of range block number in mark_block_bad");
 
-        if (unit < start_data_unit || unit >= num_sectors)
-            die("Internal error: out of range sector number in mark_FAT_sector");
-
+    for (i = 0; i < num_clusters; i++) {
+        cluster = first_cluster + i;
+        if (cluster >= fat_entries) {
+            if (verbose >= 2)
+                printf("Block number %llu is behind last cluster, no FAT entry to mark bad, ignoring\n",
+                        blockno);
+            return;
+        }
         mark_FAT_cluster(cluster, FAT_BAD);
     }
 }
@@ -416,8 +420,6 @@ static void check_blocks(void)
             continue;
         } else
             try = 1;
-        if (currently_testing < start_data_block)
-            die("bad blocks before data-area: cannot make fs");
 
         mark_block_bad(currently_testing);
         badblocks++;
@@ -433,7 +435,6 @@ static void check_blocks(void)
 
 static void get_list_blocks(char *filename)
 {
-    int i;
     FILE *listfile;
     long long blockno;
     char *line = NULL;
@@ -482,21 +483,11 @@ static void get_list_blocks(char *filename)
         if (end == line)
             continue;
 
-        /* Mark all of the sectors in the block as bad */
-        for (i = 0; i < UNITS_PER_BLOCK; i++) {
-            unsigned long long sector = blockno * UNITS_PER_BLOCK + i;
-
-            if (sector < start_data_unit) {
-                fprintf(stderr, "Block number %lld is before data area\n",
-                        blockno);
-                die("Error in bad blocks file");
-            }
-
-            if (sector >= num_sectors) {
-                fprintf(stderr, "Block number %lld is behind end of filesystem\n",
-                        blockno);
-                die("Error in bad blocks file");
-            }
+        /* Mark all of the clusters in the block as bad */
+        if (blockno >= blocks) {
+            fprintf(stderr, "Block number %lld is behind end of filesystem\n",
+                    blockno);
+            die("Error in bad blocks file");
         }
         mark_block_bad(blockno);
         badblocks++;
@@ -1202,8 +1193,6 @@ static void setup_tables(void)
 
     start_data_sector = reserved_sectors + nr_fats * fat_length +
         cdiv(root_dir_entries * 32, sector_size);
-    /* Define the smallest unit as a 512 byte sector */
-    start_data_unit = (unsigned long long)start_data_sector * sector_size / UNIT_SIZE;
     /* First block which consists entirely of data sectors */
     start_data_block = cdiv((unsigned long long)start_data_sector * sector_size, BLOCK_SIZE);
 

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -85,10 +85,6 @@
 
 /* Macro definitions */
 
-/* Mark a cluster in the FAT as bad */
-
-#define mark_unit_bad( unit ) mark_FAT_unit( unit, FAT_BAD )
-
 /* Compute ceil(a/b) */
 
 static inline int cdiv(int a, int b)
@@ -252,8 +248,9 @@ static off_t part_sector = 0; /* partition offset in sector */
 static int ignore_safety_checks = 0;	/* Ignore safety checks */
 static off_t currently_testing = 0;	/* Block currently being tested (if autodetect bad blocks) */
 static struct msdos_boot_sector bs;	/* Boot sector data */
-static int start_data_unit;	/* Sector number for the start of the data area in 512 byte sectors */
-static int start_data_block;	/* Block number for the start of the data area */
+static unsigned long long start_data_unit;	/* Sector number for the start of the data area in 512 byte sectors*/
+static unsigned long start_data_sector;	/* Sector number for the start of the data area */
+static unsigned long long start_data_block;	/* Block number for the start of the data area */
 static unsigned char *fat;	/* File allocation table */
 static unsigned alloced_fat_length;	/* # of FAT sectors we can keep in memory */
 static unsigned fat_entries;		/* total entries in FAT table (including reserved) */
@@ -280,8 +277,8 @@ static int fill_mbr_partition = -1;	/* Whether to fill MBR partition table or no
 
 /* Function prototype definitions */
 
-static void mark_FAT_cluster(int cluster, unsigned int value);
-static void mark_FAT_unit(int unit, unsigned int value);
+static void mark_FAT_cluster(long cluster, unsigned int value);
+static void mark_block_bad(unsigned long long block);
 static long do_check(char *buffer, int try, off_t current_block);
 static void alarm_intr(int alnum);
 static void check_blocks(void);
@@ -295,7 +292,7 @@ static void write_tables(void);
 
 /* Mark the specified cluster as having a particular value */
 
-static void mark_FAT_cluster(int cluster, unsigned int value)
+static void mark_FAT_cluster(long cluster, unsigned int value)
 {
 
     if (cluster < 0 || cluster >= fat_entries)
@@ -336,17 +333,22 @@ static void mark_FAT_cluster(int cluster, unsigned int value)
     }
 }
 
-/* Mark a specified 512 byte sector as having a particular value in its FAT entry */
+/* Mark a specified block as bad in its FAT entry */
 
-static void mark_FAT_unit(int unit, unsigned int value)
+static void mark_block_bad(unsigned long long blockno)
 {
-    int cluster = (unit - start_data_unit) / (int)(bs.cluster_size) /
-        (sector_size / UNIT_SIZE) + 2;
+    int i, cluster, unit;
 
-    if (unit < start_data_unit || unit >= num_sectors)
-        die("Internal error: out of range sector number in mark_FAT_sector");
+    for (i = 0; i < UNITS_PER_BLOCK; i++) {
+        unit = blockno * UNITS_PER_BLOCK + i;
+        cluster = (unit - start_data_unit) / (int)(bs.cluster_size) /
+            (sector_size / UNIT_SIZE) + 2;
 
-    mark_FAT_cluster(cluster, value);
+        if (unit < start_data_unit || unit >= num_sectors)
+            die("Internal error: out of range sector number in mark_FAT_sector");
+
+        mark_FAT_cluster(cluster, FAT_BAD);
+    }
 }
 
 /* Perform a test on a block.  Return the number of blocks that could be read successfully */
@@ -392,43 +394,41 @@ static void alarm_intr(int alnum)
 static void check_blocks(void)
 {
     int try, got;
-    int i;
     static char blkbuf[BLOCK_SIZE * TEST_BUFFER_BLOCKS];
 
     if (verbose) {
-	printf("Searching for bad blocks ");
-	fflush(stdout);
+        printf("Searching for bad blocks ");
+        fflush(stdout);
     }
     currently_testing = 0;
     if (verbose) {
-	signal(SIGALRM, alarm_intr);
-	alarm(5);
+        signal(SIGALRM, alarm_intr);
+        alarm(5);
     }
     try = TEST_BUFFER_BLOCKS;
     while (currently_testing < blocks) {
-	if (currently_testing + try > blocks)
-	    try = blocks - currently_testing; /* TODO: check overflow */
-	got = do_check(blkbuf, try, currently_testing);
-	currently_testing += got;
-	if (got == try) {
-	    try = TEST_BUFFER_BLOCKS;
-	    continue;
-	} else
-	    try = 1;
-	if (currently_testing < start_data_block)
-	    die("bad blocks before data-area: cannot make fs");
+        if (currently_testing + try > blocks)
+            try = blocks - currently_testing; /* TODO: check overflow */
+        got = do_check(blkbuf, try, currently_testing);
+        currently_testing += got;
+        if (got == try) {
+            try = TEST_BUFFER_BLOCKS;
+            continue;
+        } else
+            try = 1;
+        if (currently_testing < start_data_block)
+            die("bad blocks before data-area: cannot make fs");
 
-	for (i = 0; i < UNITS_PER_BLOCK; i++)	/* Mark all of the sectors in the block as bad */
-	    mark_unit_bad(currently_testing * UNITS_PER_BLOCK + i);
-	badblocks++;
-	currently_testing++;
+        mark_block_bad(currently_testing);
+        badblocks++;
+        currently_testing++;
     }
 
     if (verbose)
-	printf("\n");
+        printf("\n");
 
     if (badblocks)
-	printf("%d bad block%s\n", badblocks, (badblocks > 1) ? "s" : "");
+        printf("%d bad block%s\n", badblocks, (badblocks > 1) ? "s" : "");
 }
 
 static void get_list_blocks(char *filename)
@@ -443,70 +443,69 @@ static void get_list_blocks(char *filename)
 
     listfile = fopen(filename, "r");
     if (listfile == (FILE *) NULL)
-	die("Can't open file of bad blocks");
+        die("Can't open file of bad blocks");
 
     while (1) {
-	lineno++;
-	ssize_t length = getline(&line, &linesize, listfile);
-	if (length < 0) {
-	    if (errno == 0) /* end of file */
-		break;
+        lineno++;
+        ssize_t length = getline(&line, &linesize, listfile);
+        if (length < 0) {
+            if (errno == 0) /* end of file */
+                break;
 
-	    perror("getline");
-	    die("Error while reading bad blocks file");
-	}
+            perror("getline");
+            die("Error while reading bad blocks file");
+        }
 
-	errno = 0;
-	blockno = strtoll(line, &end, 10);
+        errno = 0;
+        blockno = strtoll(line, &end, 10);
 
-	if (errno || blockno < 0) {
-	    fprintf(stderr,
-		    "While converting bad block number in line %d: %s\n",
-		    lineno, strerror(errno));
-	    die("Error in bad blocks file");
-	}
+        if (errno || blockno < 0) {
+            fprintf(stderr,
+                    "While converting bad block number in line %d: %s\n",
+                    lineno, strerror(errno));
+            die("Error in bad blocks file");
+        }
 
-	check = end;
-	while (*check) {
-	    if (!isspace((unsigned char)*check)) {
-		fprintf(stderr,
-			"Badly formed number in bad blocks file line %d\n",
-			lineno);
-		die("Error in bad blocks file");
-	    }
+        check = end;
+        while (*check) {
+            if (!isspace((unsigned char)*check)) {
+                fprintf(stderr,
+                        "Badly formed number in bad blocks file line %d\n",
+                        lineno);
+                die("Error in bad blocks file");
+            }
 
-	    check++;
-	}
+            check++;
+        }
 
-	/* ignore empty or white space only lines */
-	if (end == line)
-	    continue;
+        /* ignore empty or white space only lines */
+        if (end == line)
+            continue;
 
-	/* Mark all of the sectors in the block as bad */
-	for (i = 0; i < UNITS_PER_BLOCK; i++) {
-	    unsigned long long sector = blockno * UNITS_PER_BLOCK + i;
+        /* Mark all of the sectors in the block as bad */
+        for (i = 0; i < UNITS_PER_BLOCK; i++) {
+            unsigned long long sector = blockno * UNITS_PER_BLOCK + i;
 
-	    if (sector < start_data_unit) {
-		fprintf(stderr, "Block number %lld is before data area\n",
-			blockno);
-		die("Error in bad blocks file");
-	    }
+            if (sector < start_data_unit) {
+                fprintf(stderr, "Block number %lld is before data area\n",
+                        blockno);
+                die("Error in bad blocks file");
+            }
 
-	    if (sector >= num_sectors) {
-		fprintf(stderr, "Block number %lld is behind end of filesystem\n",
-			blockno);
-		die("Error in bad blocks file");
-	    }
-
-	    mark_unit_bad(sector);
-	}
-	badblocks++;
+            if (sector >= num_sectors) {
+                fprintf(stderr, "Block number %lld is behind end of filesystem\n",
+                        blockno);
+                die("Error in bad blocks file");
+            }
+        }
+        mark_block_bad(blockno);
+        badblocks++;
     }
     fclose(listfile);
     free(line);
 
     if (badblocks)
-	printf("%d bad block%s\n", badblocks, (badblocks > 1) ? "s" : "");
+        printf("%d bad block%s\n", badblocks, (badblocks > 1) ? "s" : "");
 }
 
 /* Check to see if the specified device is currently mounted - abort if it is */
@@ -1201,11 +1200,12 @@ static void setup_tables(void)
     }
     fat_entries = cluster_count + 2;
 
+    start_data_sector = reserved_sectors + nr_fats * fat_length +
+        cdiv(root_dir_entries * 32, sector_size);
     /* Define the smallest unit as a 512 byte sector */
-    start_data_unit = (reserved_sectors + nr_fats * fat_length +
-	    cdiv(root_dir_entries * 32, sector_size)) *
-        (sector_size / UNIT_SIZE);
-    start_data_block = cdiv(start_data_unit, UNITS_PER_BLOCK);
+    start_data_unit = (unsigned long long)start_data_sector * sector_size / UNIT_SIZE;
+    /* First block which consists entirely of data sectors */
+    start_data_block = cdiv((unsigned long long)start_data_sector * sector_size, BLOCK_SIZE);
 
     if (blocks < start_data_block + 32)	/* Arbitrary undersize filesystem! */
 	die("Too few blocks for viable filesystem");


### PR DESCRIPTION
The check was for 512 byte sector number being more than actual number of sectors. Change it to block number being after number of blocks, and ignore blocks past end of last cluster.
Also remove 512 byte hard sectors.

I am new to this, suggestions and criticisms welcome!