### PR TITLE
Add flag to skip validate_volume_label

### DIFF
--- a/manpages/fatlabel.8.in
+++ b/manpages/fatlabel.8.in
@@ -51,6 +51,8 @@ Remove label in label mode or generate new ID in volume ID mode.
 .IP "\fB-c\fP \fIPAGE\fP, \fB\-\-codepage\fP=\fIPAGE\fP" 4
 Use DOS codepage \fIPAGE\fP to encode/decode label.
 By default codepage 850 is used.
+.IP "\fB\-\-skip-name-validation\fP" 4
+Do not validate filesystem label.
 .IP "\fB\-h\fP, \fB\-\-help\fP" 4
 Display a help message and terminate.
 .IP "\fB\-V\fP, \fB\-\-version\fP" 4

--- a/manpages/mkfs.fat.8.in
+++ b/manpages/mkfs.fat.8.in
@@ -220,6 +220,8 @@ volume ID and creation time.
 Multiple runs of \fBmkfs.fat\fP on the same device create identical results
 with this option.
 Its main purpose is testing \fBmkfs.fat\fP.
+.IP "\fB\-\-skip-name-validation\fP" 4
+Do not validate filesystem label.
 .\" ----------------------------------------------------------------------------
 .SH BUGS
 \fBmkfs.fat\fP can not create boot-able filesystems.

--- a/src/common.c
+++ b/src/common.c
@@ -43,6 +43,7 @@
 int interactive;
 int write_immed;
 int atari_format;
+int skip_name_validation;
 const char *program_name;
 
 
@@ -340,6 +341,9 @@ int validate_volume_label(char *doslabel)
     int i;
     int ret = 0;
     wchar_t wlabel[12];
+
+    if (skip_name_validation)
+        return 0;
 
     if (dos_string_to_wchar_string(wlabel, doslabel, sizeof(wlabel))) {
         for (i = 0; wlabel[i]; i++) {

--- a/src/common.h
+++ b/src/common.h
@@ -35,6 +35,7 @@
 extern int interactive;
 extern int write_immed;
 extern int atari_format;	/* Use Atari variation of MS-DOS FS format */
+extern int skip_name_validation;
 
 /* program_name used for printing messages; no name will be printed when it is
  * left as NULL */

--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -196,21 +196,24 @@ static void usage(char *name, int error, int usage_only)
     fprintf(f, "existing label or serial if NEW is not given.\n");
     fprintf(f, "\n");
     fprintf(f, "Options:\n");
-    fprintf(f, "  -i, --volume-id     Work on serial number instead of label\n");
-    fprintf(f, "  -r, --reset         Remove label or generate new serial number\n");
-    fprintf(f, "  -c N, --codepage=N  use DOS codepage N to encode/decode label (default: %d)\n", DEFAULT_DOS_CODEPAGE);
-    fprintf(f, "  -V, --version       Show version number and terminate\n");
-    fprintf(f, "  -h, --help          Print this message and terminate\n");
+    fprintf(f, "  -i, --volume-id        Work on serial number instead of label\n");
+    fprintf(f, "  -r, --reset            Remove label or generate new serial number\n");
+    fprintf(f, "  -c N, --codepage=N     use DOS codepage N to encode/decode label (default: %d)\n", DEFAULT_DOS_CODEPAGE);
+    fprintf(f, "  --skip-name-validation Do not validate filesystem label\n");
+    fprintf(f, "  -V, --version          Show version number and terminate\n");
+    fprintf(f, "  -h, --help             Print this message and terminate\n");
     exit(status);
 }
 
 
 int main(int argc, char *argv[])
 {
+    enum {OPT_SKIP_NAME_VALIDATION=1000};
     const struct option long_options[] = {
 	{"volume-id", no_argument, NULL, 'i'},
 	{"reset",     no_argument, NULL, 'r'},
 	{"codepage",  required_argument, NULL, 'c'},
+	{"skip-name-validation", optional_argument, NULL, OPT_SKIP_NAME_VALIDATION},
 	{"version",   no_argument, NULL, 'V'},
 	{"help",      no_argument, NULL, 'h'},
 	{0,}
@@ -245,6 +248,10 @@ int main(int argc, char *argv[])
 		}
 		if (!set_dos_codepage(codepage))
 		    usage(argv[0], 1, 0);
+		break;
+
+	    case OPT_SKIP_NAME_VALIDATION:
+		skip_name_validation = 1;
 		break;
 
 	    case 'V':

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1424,33 +1424,33 @@ static void usage(const char *name, int exitval)
     fprintf(stderr, "created with a size of 1024 bytes times BLOCKS, which must be specified.\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -a              Disable alignment of data structures\n");
-    fprintf(stderr, "  -A              Toggle Atari variant of the filesystem\n");
-    fprintf(stderr, "  -b SECTOR       Select SECTOR as location of the FAT32 backup boot sector\n");
-    fprintf(stderr, "  -c              Check device for bad blocks before creating the filesystem\n");
-    fprintf(stderr, "  -C              Create file TARGET then create filesystem in it\n");
-    fprintf(stderr, "  -D NUMBER       Write BIOS drive number NUMBER to boot sector\n");
-    fprintf(stderr, "  -f COUNT        Create COUNT file allocation tables\n");
-    fprintf(stderr, "  -F SIZE         Select FAT size SIZE (12, 16 or 32)\n");
-    fprintf(stderr, "  -g GEOM         Select disk geometry: heads/sectors_per_track\n");
-    fprintf(stderr, "  -h NUMBER       Write hidden sectors NUMBER to boot sector\n");
-    fprintf(stderr, "  -i VOLID        Set volume ID to VOLID (a 32 bit hexadecimal number)\n");
-    fprintf(stderr, "  -I              Ignore and disable safety checks\n");
-    fprintf(stderr, "  -l FILENAME     Read bad blocks list from FILENAME\n");
-    fprintf(stderr, "  -m FILENAME     Replace default error message in boot block with contents of FILENAME\n");
-    fprintf(stderr, "  -M TYPE         Set media type in boot sector to TYPE\n");
-    fprintf(stderr, "  --mbr[=y|n|a]   Fill (fake) MBR table with one partition which spans whole disk\n");
-    fprintf(stderr, "  -n LABEL        Set volume name to LABEL (up to 11 characters long)\n");
-    fprintf(stderr, "  --codepage=N    use DOS codepage N to encode label (default: %d)\n", DEFAULT_DOS_CODEPAGE);
-    fprintf(stderr, "  -r COUNT        Make room for at least COUNT entries in the root directory\n");
-    fprintf(stderr, "  -R COUNT        Set minimal number of reserved sectors to COUNT\n");
-    fprintf(stderr, "  -s COUNT        Set number of sectors per cluster to COUNT\n");
-    fprintf(stderr, "  -S SIZE         Select a sector size of SIZE (a power of two, at least 512)\n");
-    fprintf(stderr, "  -v              Verbose execution\n");
-    fprintf(stderr, "  --variant=TYPE  Select variant TYPE of filesystem (standard or Atari)\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  --offset=SECTOR Write the filesystem at a specific sector into the device file.\n");
-    fprintf(stderr, "  --help          Show this help message and exit\n");
+    fprintf(stderr, "  -a                     Disable alignment of data structures\n");
+    fprintf(stderr, "  -A                     Toggle Atari variant of the filesystem\n");
+    fprintf(stderr, "  -b SECTOR              Select SECTOR as location of the FAT32 backup boot sector\n");
+    fprintf(stderr, "  -c                     Check device for bad blocks before creating the filesystem\n");
+    fprintf(stderr, "  -C                     Create file TARGET then create filesystem in it\n");
+    fprintf(stderr, "  -D NUMBER              Write BIOS drive number NUMBER to boot sector\n");
+    fprintf(stderr, "  -f COUNT               Create COUNT file allocation tables\n");
+    fprintf(stderr, "  -F SIZE                Select FAT size SIZE (12, 16 or 32)\n");
+    fprintf(stderr, "  -g GEOM                Select disk geometry: heads/sectors_per_track\n");
+    fprintf(stderr, "  -h NUMBER              Write hidden sectors NUMBER to boot sector\n");
+    fprintf(stderr, "  -i VOLID               Set volume ID to VOLID (a 32 bit hexadecimal number)\n");
+    fprintf(stderr, "  -I                     Ignore and disable safety checks\n");
+    fprintf(stderr, "  -l FILENAME            Read bad blocks list from FILENAME\n");
+    fprintf(stderr, "  -m FILENAME            Replace default error message in boot block with contents of FILENAME\n");
+    fprintf(stderr, "  -M TYPE                Set media type in boot sector to TYPE\n");
+    fprintf(stderr, "  --mbr[=y|n|a]          Fill (fake) MBR table with one partition which spans whole disk\n");
+    fprintf(stderr, "  -n LABEL               Set volume name to LABEL (up to 11 characters long)\n");
+    fprintf(stderr, "  --codepage=N           use DOS codepage N to encode label (default: %d)\n", DEFAULT_DOS_CODEPAGE);
+    fprintf(stderr, "  -r COUNT               Make room for at least COUNT entries in the root directory\n");
+    fprintf(stderr, "  -R COUNT               Set minimal number of reserved sectors to COUNT\n");
+    fprintf(stderr, "  -s COUNT               Set number of sectors per cluster to COUNT\n");
+    fprintf(stderr, "  -S SIZE                Select a sector size of SIZE (a power of two, at least 512)\n");
+    fprintf(stderr, "  -v                     Verbose execution\n");
+    fprintf(stderr, "  --variant=TYPE         Select variant TYPE of filesystem (standard or Atari)\n");
+    fprintf(stderr, "  --skip-name-validation Do not validate filesystem label\n");
+    fprintf(stderr, "  --offset=SECTOR        Write the filesystem at a specific sector into the device file.\n");
+    fprintf(stderr, "  --help                 Show this help message and exit\n");
     exit(exitval);
 }
 
@@ -1472,14 +1472,15 @@ int main(int argc, char **argv)
     long long conversion;
     char *source_date_epoch = NULL;
 
-    enum {OPT_HELP=1000, OPT_INVARIANT, OPT_MBR, OPT_VARIANT, OPT_CODEPAGE, OPT_OFFSET};
+    enum {OPT_HELP=1000, OPT_INVARIANT, OPT_MBR, OPT_VARIANT, OPT_CODEPAGE, OPT_OFFSET, OPT_SKIP_NAME_VALIDATION};
     const struct option long_options[] = {
-	    {"codepage",  required_argument, NULL, OPT_CODEPAGE},
-	    {"invariant", no_argument,       NULL, OPT_INVARIANT},
-	    {"mbr",       optional_argument, NULL, OPT_MBR},
-	    {"variant",   required_argument, NULL, OPT_VARIANT},
-	    {"offset",    required_argument, NULL, OPT_OFFSET},
-	    {"help",      no_argument,       NULL, OPT_HELP},
+	    {"codepage",             required_argument, NULL, OPT_CODEPAGE},
+	    {"invariant",            no_argument,       NULL, OPT_INVARIANT},
+	    {"mbr",                  optional_argument, NULL, OPT_MBR},
+	    {"variant",              required_argument, NULL, OPT_VARIANT},
+	    {"offset",               required_argument, NULL, OPT_OFFSET},
+	    {"skip-name-validation", optional_argument, NULL, OPT_SKIP_NAME_VALIDATION},
+	    {"help",                 no_argument,       NULL, OPT_HELP},
 	    {0,}
     };
 
@@ -1818,6 +1819,10 @@ int main(int argc, char **argv)
 
         part_sector = (off_t) conversion;
         break;
+
+	case OPT_SKIP_NAME_VALIDATION:
+		skip_name_validation = 1;
+		break;
 
 	case '?':
 	    usage(argv[0], 1);


### PR DESCRIPTION
Extra validations were introduced in ca549534762c, let's have an option to skip them. All tools I tested can deal with invalid characters correctly.

Tested with:

    $ sudo src/fatlabel /dev/vda1 A_B
    $ sudo src/fatlabel /dev/vda1 A+B
    fatlabel: labels with characters *?.,;:/\|+=<>[]" are not allowed
    $ sudo src/fatlabel /dev/vda1 A+B --skip-name-validation
    $ sudo mount /dev/vda1 /boot/efi
    $ sudo blkid -c /dev/null | grep vda1
    /dev/vda1: SEC_TYPE="msdos" LABEL_FATBOOT="A+B" LABEL="A+B" \
    UUID="ECFC-989A" BLOCK_SIZE="512" TYPE="vfat" \
    PARTLABEL="EFI System Partition" \
    PARTUUID="5c481284-4af4-437f-93b6-6fb2721a75d2"

    $ fallocate -l 1G ~/tmp.img
    $ src/mkfs.fat -n A+B ~/tmp.img
    mkfs.fat 4.2+git (2021-01-31)
    mkfs.fat: Labels with characters *?.,;:/\|+=<>[]" are not allowed
    $ src/mkfs.fat -n A+B ~/tmp.img --skip-name-validation
    mkfs.fat 4.2+git (2021-01-31)
    $ file ~/tmp.img
    /home/pzmarzly.linux/tmp.img: DOS/MBR boot sector, \
    code offset 0x58+2, OEM-ID "mkfs.fat", sectors/cluster 8, \
    Media descriptor 0xf8, sectors/track 63, heads 64, \
    sectors 2097144 (volumes > 32 MB), FAT (32 bit), sectors/FAT 2048, \
    serial number 0x5ccb07ce, label: "A+B        "