### PR TITLE
Support multiple codepage command line arguments.

### DIFF
--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
     char *device = NULL;
     char *new = NULL;
     char *tmp;
-    long codepage;
+    long codepage = -1;
     int c;
 
     check_atari();
@@ -243,8 +243,6 @@ int main(int argc, char *argv[])
 		    fprintf(stderr, "Invalid codepage : %s\n", optarg);
 		    usage(argv[0], 1, 0);
 		}
-		if (!set_dos_codepage(codepage))
-		    usage(argv[0], 1, 0);
 		break;
 
 	    case 'V':
@@ -267,7 +265,7 @@ int main(int argc, char *argv[])
 	}
     }
 
-    if (!set_dos_codepage(-1))	/* set default codepage if none was given in command line */
+    if (!set_dos_codepage(codepage))
         exit(1);
 
     if (optind == argc - 2) {

--- a/src/fsck.fat.c
+++ b/src/fsck.fat.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
     uint32_t free_clusters = 0;
     struct termios tio;
     char *tmp;
-    long codepage;
+    long codepage = -1;
 
     enum {OPT_HELP=1000, OPT_VARIANT};
     const struct option long_options[] = {
@@ -151,8 +151,6 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Invalid codepage : %s\n", optarg);
 		usage(argv[0], 2);
 	    }
-	    if (!set_dos_codepage(codepage))
-		usage(argv[0], 2);
 	    break;
 	case 'd':
 	    file_add(optarg, fdt_drop);
@@ -221,7 +219,7 @@ int main(int argc, char **argv)
 		    "Internal error: getopt_long() returned unexpected value %d\n", c);
 	    exit(3);
 	}
-    if (!set_dos_codepage(-1))	/* set default codepage if none was given in command line */
+    if (!set_dos_codepage(codepage))
         exit(2);
     if ((test || write_immed) && !rw) {
 	fprintf(stderr, "-t and -w can not be used in read only mode\n");

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1471,6 +1471,7 @@ int main(int argc, char **argv)
     struct timeval create_timeval;
     long long conversion;
     char *source_date_epoch = NULL;
+    long codepage = -1;
 
     enum {OPT_HELP=1000, OPT_INVARIANT, OPT_MBR, OPT_VARIANT, OPT_CODEPAGE, OPT_OFFSET};
     const struct option long_options[] = {
@@ -1715,8 +1716,7 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Invalid codepage : %s\n", optarg);
 		usage(argv[0], 1);
 	    }
-	    if (!set_dos_codepage(conversion))
-		usage(argv[0], 1);
+	    codepage = conversion;
 	    break;
 
 	case 'r':		/* r : Root directory entries */
@@ -1829,7 +1829,7 @@ int main(int argc, char **argv)
 	    exit(2);
 	}
 
-    if (!set_dos_codepage(-1))	/* set default codepage if none was given in command line */
+    if (!set_dos_codepage(codepage))
         exit(1);
 
     if (optind == argc || !argv[optind]) {


### PR DESCRIPTION
Use last given codepage argument instead of first to comply with other command line arguments.

Proof of Concept:

1. Prepare a filesystem with label ° in codepage 1252
```
$ dd if=/dev/zero of=poc.iso bs=512 count=100
$ mkfs.fat -c 1252 -n "°" poc.iso
```

2. Query the label
```
$ fatlabel -c 1252 poc.iso
$ fatlabel -c 850 -c 1252 poc.iso
```

The output should be identical.

Signed-off-by: Samanta Navarro <ferivoz@riseup.net>