### PR TITLE
fatlabel: Fix a compiler warning about a maybe-unitialized variable

### DIFF
--- a/src/fatlabel.c
+++ b/src/fatlabel.c
@@ -215,7 +215,7 @@ int main(int argc, char *argv[])
 	{"help",      no_argument, NULL, 'h'},
 	{0,}
     };
-    bool change;
+    bool change = false;
     bool reset = false;
     bool volid_mode = false;
     char *device = NULL;


### PR DESCRIPTION
Fixes a compiler error that can occur when building with clang: `error: variable 'change' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]`

Previously, this variable was initialized on all code paths except for one that called `usage(1, 1)`.  In practice that should have been safe as `usage` should cause the program to exit.  But to make this obviously safe, initialize `change` to false when it is declared.