### PR TITLE
fsck.fat: Reduce duplicate file name lookups

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -108,7 +108,10 @@ off_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern, int ge
 	if (gen_name) {
 	    while (1) {
 		char expanded[12];
+		if (curr_num >= 10000)
+		    die("Unable to create unique name");
 		sprintf(expanded, pattern, curr_num);
+		curr_num++;
 		memcpy(de->name, expanded, MSDOS_NAME);
 		clu_num = fs->root_cluster;
 		i = 0;
@@ -130,8 +133,6 @@ off_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern, int ge
 		}
 		if (clu_num == 0 || clu_num == -1)
 		    break;
-		if (++curr_num >= 10000)
-		    die("Unable to create unique name");
 	    }
 	} else {
 	    memcpy(de->name, pattern, MSDOS_NAME);
@@ -156,7 +157,10 @@ off_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern, int ge
 	if (gen_name) {
 	    while (1) {
 		char expanded[12];
+		if (curr_num >= 10000)
+		    die("Unable to create unique name");
 		sprintf(expanded, pattern, curr_num);
+		curr_num++;
 		memcpy(de->name, expanded, MSDOS_NAME);
 		for (scan = 0; scan < fs->root_entries; scan++)
 		    if (scan != next_free &&
@@ -165,8 +169,6 @@ off_t alloc_rootdir_entry(DOS_FS * fs, DIR_ENT * de, const char *pattern, int ge
 			break;
 		if (scan == fs->root_entries)
 		    break;
-		if (++curr_num >= 10000)
-		    die("Unable to create unique name");
 	    }
 	} else {
 	    memcpy(de->name, pattern, MSDOS_NAME);


### PR DESCRIPTION
If a file has to be generated, then alloc_rootdir_entry tries to create a unique name by using a counter curr_num for name generation and looking for duplicates. If no duplicate is found, the counter curr_num is not incremented, which means that the next file uses the same name again. It is only incremented after the previously created file is detected, just to repeat the loop again.

The improvement is simple: Increment the counter after creating the filename. This has also the benefit that the check and use of curr_num are closer to each other within the source code.