### PR TITLE
fsck.fat: Use fsck return codes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,23 @@
+dosfstools 5.0 - released <TBD>
+===============================
+
+fsck.fat has exit codes compliant to the standard fsck exit codes (see man
+fsck). The return codes of fatlabel and mkfs.fat changed as well.
+
+The exit code returned by fsck is the sum of the following conditions:
+
+0 - No errors
+1 - File system errors corrected
+2 - System should be rebooted
+4 - File system errors left uncorrected
+8 - Operational error
+16 - Usage or syntax error
+32 - Fsck canceled by user request
+128 - Shared library error
+
+The exit code returned when multiple file systems are checked is the bit-wise
+OR of the exit codes for each file system that is checked.
+
 dosfstools 4.2 - released 2021-01-31
 ====================================
 

--- a/manpages/fsck.fat.8.in
+++ b/manpages/fsck.fat.8.in
@@ -222,13 +222,21 @@ Display help message describing usage and options then exit.
 .\" ----------------------------------------------------------------------------
 .SH "EXIT STATUS"
 .IP "0" 4
-No recoverable errors have been detected.
+No errors
 .IP "1" 4
-Recoverable errors have been detected or \fBfsck.fat\fP has discovered an
-internal inconsistency.
+Filesystem errors corrected
 .IP "2" 4
-Usage error.
-\fBfsck.fat\fP did not access the filesystem.
+System should be rebooted
+.IP "4" 4
+Filesystem errors left uncorrected
+.IP "8" 4
+Operational error
+.IP "16" 4
+Usage or syntax error
+.IP "32" 4
+Checking canceled by user request
+.IP "128" 4
+Shared-library error
 .\" ----------------------------------------------------------------------------
 .SH FILES
 .IP "\fIfsck0000.rec\fP, \fIfsck0001.rec\fP, ..." 4

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,7 @@ EXTRA_DIST = blkdev/README
 
 charconv_common_sources = charconv.c charconv.h
 charconv_common_ldadd = $(LIBICONV)
-fscklabel_common_sources = boot.c boot.h common.c common.h \
+fscklabel_common_sources = boot.c boot.h common.c common.h exit_codes.h \
 			   fat.c fat.h io.c io.h msdos_fs.h \
 			   $(charconv_common_sources) \
 			   fsck.fat.h endian_compat.h
@@ -38,7 +38,7 @@ devinfo_common_sources = device_info.c device_info.h \
 			 blkdev/blkdev.c blkdev/blkdev.h \
 			 blkdev/linux_version.c blkdev/linux_version.h
 mkfs_fat_SOURCES  = mkfs.fat.c msdos_fs.h common.c common.h endian_compat.h \
-		    $(charconv_common_sources) $(devinfo_common_sources)
+		    exit_codes.h $(charconv_common_sources) $(devinfo_common_sources)
 mkfs_fat_CPPFLAGS = -I$(srcdir)/blkdev
 mkfs_fat_CFLAGS   = $(AM_CFLAGS)
 mkfs_fat_LDADD    = $(charconv_common_ldadd)

--- a/src/common.c
+++ b/src/common.c
@@ -38,7 +38,7 @@
 
 #include "common.h"
 #include "charconv.h"
-
+#include "exit_codes.h"
 
 int interactive;
 int write_immed;
@@ -62,7 +62,7 @@ void die(const char *msg, ...)
     vfprintf(stderr, msg, args);
     va_end(args);
     fprintf(stderr, "\n");
-    exit(1);
+    exit(OPERATIONAL_ERROR);
 }
 
 void pdie(const char *msg, ...)
@@ -76,7 +76,7 @@ void pdie(const char *msg, ...)
     vfprintf(stderr, msg, args);
     va_end(args);
     fprintf(stderr, ": %s\n", strerror(errno));
-    exit(1);
+    exit(OPERATIONAL_ERROR);
 }
 
 void *alloc(int size)
@@ -205,7 +205,7 @@ int get_choice(int noninteractive_result, const char *noninteractive_msg,
 	} while (choice == '\n');  /* filter out enter presses */
 
 	if (choice == EOF)
-	    exit(1);
+	    exit(USAGE_OR_SYNTAX_ERROR);
 
 	printf("%c\n", choice);
 
@@ -235,7 +235,7 @@ int get_choice(int noninteractive_result, const char *noninteractive_msg,
 	    inhibit_quit_choice = 0;
 
 	    if (quit_choice == 1)
-		exit(0);
+		exit(NO_ERRORS);
 	}
     }
 

--- a/src/exit_codes.h
+++ b/src/exit_codes.h
@@ -1,0 +1,15 @@
+#ifndef _EXIT_CODES_H
+#define _EXIT_CODES_H
+
+/* Codes as defined by fsck.
+   For more information, see fsck manpage. */
+#define NO_ERRORS                   0
+#define FS_ERRORS_CORRECTED         1
+#define SYSTEM_SHOULD_BE_REBOOTED   2
+#define FS_ERRORS_LEFT_UNCORRECTED  4
+#define OPERATIONAL_ERROR           8
+#define USAGE_OR_SYNTAX_ERROR       16
+#define CHECKING_CANCELED_BY_USER   32
+#define SHARED_LIB_ERROR            128
+
+#endif

--- a/src/fsck.fat.c
+++ b/src/fsck.fat.c
@@ -46,6 +46,7 @@
 #include "file.h"
 #include "check.h"
 #include "charconv.h"
+#include "exit_codes.h"
 
 int rw = 0, list = 0, test = 0, verbose = 0;
 long fat_table = 0;
@@ -149,7 +150,7 @@ int main(int argc, char **argv)
 	    codepage = strtol(optarg, &tmp, 10);
 	    if (!*optarg || isspace((unsigned char)*optarg) || *tmp || errno || codepage < 0 || codepage > INT_MAX) {
 		fprintf(stderr, "Invalid codepage : %s\n", optarg);
-		usage(argv[0], 2);
+		usage(argv[0], USAGE_OR_SYNTAX_ERROR);
 	    }
 	    break;
 	case 'd':
@@ -163,7 +164,7 @@ int main(int argc, char **argv)
 	    fat_table = strtol(optarg, &tmp, 10);
 	    if (!*optarg || isspace((unsigned char)*optarg) || *tmp || errno || fat_table < 0 || fat_table > 255) {
 		fprintf(stderr, "Invalid FAT table : %s\n", optarg);
-		usage(argv[0], 2);
+		usage(argv[0], USAGE_OR_SYNTAX_ERROR);
 	    }
 	    break;
 	case 'l':
@@ -202,31 +203,31 @@ int main(int argc, char **argv)
 		    atari_format = 1;
 	    } else {
 		    fprintf(stderr, "Unknown variant: %s\n", optarg);
-		    usage(argv[0], 2);
+		    usage(argv[0], USAGE_OR_SYNTAX_ERROR);
 	    }
 	    break;
 	case 'w':
 	    write_immed = 1;
 	    break;
 	case OPT_HELP:
-	    usage(argv[0], 0);
+	    usage(argv[0], NO_ERRORS);
 	    break;
 	case '?':
-	    usage(argv[0], 2);
+	    usage(argv[0], USAGE_OR_SYNTAX_ERROR);
 	    break;
 	default:
 	    fprintf(stderr,
 		    "Internal error: getopt_long() returned unexpected value %d\n", c);
-	    exit(3);
+	    exit(USAGE_OR_SYNTAX_ERROR);
 	}
     if (!set_dos_codepage(codepage))
-        exit(2);
+        exit(USAGE_OR_SYNTAX_ERROR);
     if ((test || write_immed) && !rw) {
 	fprintf(stderr, "-t and -w can not be used in read only mode\n");
-	exit(2);
+	exit(USAGE_OR_SYNTAX_ERROR);
     }
     if (optind != argc - 1)
-	usage(argv[0], 2);
+	usage(argv[0], USAGE_OR_SYNTAX_ERROR);
 
     fs_open(argv[optind], rw);
 
@@ -284,5 +285,5 @@ exit:
 	       n_files, (unsigned long)fs.data_clusters - free_clusters,
 	       (unsigned long)fs.data_clusters);
 
-    return fs_close(rw) ? 1 : 0;
+    return fs_close(rw) ? FS_ERRORS_CORRECTED : NO_ERRORS;
 }

--- a/src/io.c
+++ b/src/io.c
@@ -44,6 +44,7 @@
 #include "fsck.fat.h"
 #include "common.h"
 #include "io.h"
+#include "exit_codes.h"
 
 typedef struct _change {
     void *data;
@@ -60,7 +61,7 @@ void fs_open(const char *path, int rw)
 {
     if ((fd = open(path, rw ? O_RDWR : O_RDONLY)) < 0) {
 	perror("open");
-	exit(6);
+	exit(OPERATIONAL_ERROR);
     }
     changes = last = NULL;
     did_change = 0;


### PR DESCRIPTION
# Summary

This PR updates the fsck.vfat exit codes to comply with those specified by fsck [1], addressing issue #89.

Since code is shared between fsck, fatlabel, and mkfs.fat, all three tools are affected. However, as fatlabel and mkfs.fat are not required to follow any standard exit codes [2][3], this change should not pose any issues for them.

Finally, because these changes represents a breaking change, this PR also proposes creating a new major release to document the updated exit codes.

# Test evidences

1. Execution of unit-tests:

``` bash
$ make check
...
PASS: referenceFAT12.mkfs
PASS: referenceFAT16.mkfs
PASS: referenceFAT32.mkfs
PASS: referenceFAT32mbr.mkfs
PASS: mkfs-fat32_1_bad_block.mkfs
PASS: mkfs-fat32_2_res_sects.mkfs
PASS: mkfs-fat32_4K.mkfs
PASS: check-bad_names.fsck
PASS: check-fat12_first_cluster.fsck
PASS: check-fat16_first_cluster.fsck
PASS: check-fat32_first_cluster.fsck
PASS: check-fat16_dos_cln_shut.fsck
PASS: check-fat32_dos_cln_shut.fsck
PASS: check-chain_to_free_cluster.fsck
PASS: check-chain_too_long.fsck
PASS: check-chain_to_other_file.fsck
PASS: check-circular_chain.fsck
PASS: check-duplicate_names.fsck
PASS: check-dot_entries.fsck
XFAIL: check-huge.fsck
PASS: check-label-different.fsck
PASS: check-label-only-boot.fsck
PASS: check-label-only-root.fsck
PASS: check-encryption_with_invalid_83.fsck
PASS: check-encryption_with_duplicate_dirent.fsck
PASS: label-fat32_mkdosfs_label1_dosfslabel_empty.label
PASS: label-fat32_mkdosfs_label1_dosfslabel_label2.label
PASS: label-fat32_mkdosfs_label1_dosfslabel_NO_NAME.label
PASS: label-fat32_mkdosfs_label1_mlabel_erase.label
PASS: label-fat32_mkdosfs_label1_mlabel_NO_NAME.label
PASS: label-fat32_mkdosfs_label1_xp_erase.label
PASS: label-fat32_mkdosfs_label1_xp_label2.label
PASS: label-fat32_mkdosfs_label1.label
PASS: label-fat32_mkdosfs_none_dosfslabel_label1_xp_label2.label
PASS: label-fat32_mkdosfs_none_dosfslabel_label1.label
PASS: label-fat32_mkdosfs_none_dosfslabel_NO_NAME.label
PASS: label-fat32_mkdosfs_none_xp_label1_dosfslabel_label2.label
PASS: label-fat32_mkdosfs_none_xp_label1.label
PASS: label-fat32_mkdosfs_none.label
PASS: label-fat32_xp_label1.label
PASS: label-fat32_xp_none_dosfslabel_label1.label
PASS: label-fat32_xp_none_mlabel_label1.label
PASS: label-fat32_xp_none.label
============================================================================
Testsuite summary for dosfstools 4.2+git
============================================================================
# TOTAL: 43
# PASS:  42
# SKIP:  0
# XFAIL: 1
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

2. Integration tests

2.1 Execution of fsck.fat against a read-only sd-card:

The below test shows that when fsck runs against a read only fs, it will return 4, meaning that filesystem were errors left uncorrected.

``` bash
$  sudo ./src/fsck.fat /dev/sdb3
fsck.fat 4.2+git (2021-01-31)
open: Read-only file system
$ echo $?
4
```

2.2 Execution of fsck.fat with an incorrect parameter:

The below test shows that when fsck is executed with an invalid parameter, it now returns 16, meaning usage or syntax error detected.

``` bash
$ ./src/fsck.fat -c " "
fsck.fat 4.2+git (2021-01-31)
Invalid codepage :
...
$ echo $?
16
```

[1] https://man7.org/linux/man-pages/man8/fsck.8.html
[2] https://man7.org/linux/man-pages/man8/fatlabel.8.html
[3] https://man7.org/linux/man-pages/man8/mkfs.8.html