### PR TITLE
Language fix for volume label -related error message.

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -1316,7 +1316,7 @@ again:
     if (offset != 0 && memcmp(fs->label, "NO NAME    ", 11) != 0 && memcmp(fs->label, doslabel, 11) != 0) {
         strncpy(buffer, pretty_label(doslabel, 0), sizeof(buffer)-1);
         buffer[sizeof(buffer)-1] = 0;
-        printf("Volume label '%s' stored in root directory and label '%s' stored in boot sector and different.\n", buffer, pretty_label(fs->label, 0));
+        printf("Volume label '%s' stored in root directory and label '%s' stored in boot sector are different.\n", buffer, pretty_label(fs->label, 0));
         switch (get_choice(1, "  Auto-copying volume label from root directory to boot sector.",
                            3,
                            1, "Copy volume label from root directory to boot sector",


### PR DESCRIPTION
Encountered weirdly worded error message once many moons ago, using fsck.fat, rediscovered today, thought to find the source of it. Ended up here...

Hopefully that one-word change is acceptable.

Original error message:
$ sudo fsck /dev/sdc1 
fsck from util-linux 2.38.1
fsck.fat 4.2 (2021-01-31) 
... 
Volume label 'EOS_DIGITAL' stored in root directory and label 'EOS_DEVELOP' stored in boot sector and different. <-- "... are different."?
...

