### PR TITLE
fix handling of missing const type qualifier

### DIFF
--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1561,7 +1561,7 @@ int main(int argc, char **argv)
 
     program_name = "mkfs.fat";
     if (argc && *argv) {	/* What's the program name? */
-	char *p;
+	const char *p;
 	program_name = *argv;
 	if ((p = strrchr(program_name, '/')))
 	    program_name = p + 1;


### PR DESCRIPTION
For ISO C23, the function strrchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

Update to const type for variable, as returned string is only used in comparisons which const can be used

fixes:
```
../../src/mkfs.fat.c: In function 'main':
../../src/mkfs.fat.c:1496:16: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 1496 |         if ((p = strrchr(program_name, '/')))
      |                ^
```